### PR TITLE
Add Cursor Cloud Agent environment.json for Go

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "name": "ANA Go",
+  "install": "go mod download"
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `.cursor/environment.json` so Cursor Cloud Agents use a predictable bootstrap for this Go module: on VM startup they run `go mod download` after the repo is checked out, matching the dependency setup implied by `go.mod` / `go.sum`.

## Why

[Cursor Cloud Agent setup](https://cursor.com/docs/cloud-agent/setup) resolves repo-level `.cursor/environment.json` first. Without it, agents rely on personal/team defaults. A minimal `install` keeps cold starts reproducible for CI-like workflows (`go build`, `go test`, `go vet`) without custom Docker unless we need toolchains beyond the default Ubuntu image.

## Verification

- `gofmt -s -w .`
- `go vet ./...`
- `go test ./...`
- `go build ./...`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a3f7f67a-348f-465e-bd73-c47fdbf186d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a3f7f67a-348f-465e-bd73-c47fdbf186d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

