### PR TITLE
Scope git conventions Cursor rule with globs

### DIFF
--- a/.cursor/rules/git-conventions.mdc
+++ b/.cursor/rules/git-conventions.mdc
@@ -1,0 +1,40 @@
+---
+description: Branch naming, commit messages, and signing requirements for git work in this repo
+alwaysApply: true
+---
+
+# Git conventions
+
+Follow these rules for **every** git operation in this repository (local work, Cursor agents, and CI-related branches unless a maintainer overrides for automation).
+
+## Branch names
+
+Use this format only:
+
+`<type>/<content>-<date>`
+
+- **`type`**: Short category for the change (examples: `feature`, `fix`, `chore`, `refactor`; pick the closest match).
+- **`content`**: Brief, hyphenated slug describing the work (lowercase ASCII, avoid spaces).
+- **`date`**: Six digits **`YYMMDD`** (example: `260423` for 2026-04-23).
+
+Examples:
+
+- `feature/add-metrics-260423`
+- `fix/nil-pointer-parser-260423`
+- `chore/update-ci-260423`
+
+Do **not** use other prefixes (for example `cursor/` unless the team explicitly adopts them).
+
+## Commit messages
+
+1. Write messages that describe **only** the code change (what and why in plain language). No marketing or tool attribution.
+2. Do **not** include phrases such as **"Made with Cursor"**, **"Made with Codex"**, or similar agent/product footers anywhere in the subject or body.
+
+## Signed commits
+
+Commits **must** be cryptographically signed.
+
+- Prefer **SSH signing** (`git config gpg.format ssh` + `user.signingkey`) or **GPG signing** as documented in Git’s “Signing commits” guides.
+- Use `git commit -S` (capital S) when committing.
+
+If signing is not configured on a machine, configure it before pushing; do not bypass this requirement with `--no-gpg-sign` unless a repository maintainer explicitly allows an exception for a given automation path.

--- a/.cursor/rules/git-conventions.mdc
+++ b/.cursor/rules/git-conventions.mdc
@@ -1,11 +1,18 @@
 ---
 description: Branch naming, commit messages, and signing requirements for git work in this repo
-alwaysApply: true
+alwaysApply: false
+globs:
+  - ".cursor/rules/git-conventions.mdc"
+  - "AGENTS.md"
+  - ".cursor/environment.json"
+  - ".github/**/*.yml"
 ---
 
 # Git conventions
 
-Follow these rules for **every** git operation in this repository (local work, Cursor agents, and CI-related branches unless a maintainer overrides for automation).
+Cursor attaches this rule when files matching **`globs`** are in scope (for example open or referenced). It does **not** hook into `git checkout` / `git commit` automatically—when creating a branch or writing a commit message without touching those paths, rely on **`AGENTS.md`** or paste the conventions manually.
+
+Follow these rules for git operations in this repository (local work, Cursor agents, and CI-related branches unless a maintainer overrides for automation).
 
 ## Branch names
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,10 @@
 - Keep rules minimal, practical, and easy to enforce in daily work.
 - If a more specific rule (package-level doc, directory-level `AGENTS.md`, or explicit user instruction) conflicts with this document, the more specific rule wins.
 
+## Git branches and commits
+
+Branch naming, commit message wording, and signing requirements are defined in `.cursor/rules/git-conventions.mdc`. Read that file (or ensure it is in Cursor context via its `globs`) before creating branches, committing, or editing CI workflows.
+
 ## Style And Formatting
 - Always format code with `gofmt -s` (or `go fmt ./...`) and make sure `go vet ./...` is clean before committing.
 - Use clear, intention-revealing names; avoid abbreviations unless they are standard in Go.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates `.cursor/rules/git-conventions.mdc`:

- Sets **`alwaysApply: false`** and adds **`globs`** so the rule is attached when relevant files are in scope (this repo: the rule file itself, `AGENTS.md`, `.cursor/environment.json`, `.github/**/*.yml`), instead of on every chat.

Adds a short **Git branches and commits** pointer in **`AGENTS.md`** so humans/agents still know where the full conventions live.

## Note on Cursor behavior

Cursor rules cannot hook git CLI events directly; globs approximate “when editing repo git/CI setup.” For branch/commit work without those files open, see **`AGENTS.md`** or paste conventions manually.

## Verification

`go vet ./...`, `go test ./...`, `go build ./...`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a3f7f67a-348f-465e-bd73-c47fdbf186d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a3f7f67a-348f-465e-bd73-c47fdbf186d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

