### PR TITLE
Use short always-on git rule with separate detail file

### DIFF
--- a/.cursor/rules/git-conventions.detail.mdc
+++ b/.cursor/rules/git-conventions.detail.mdc
@@ -1,0 +1,46 @@
+---
+description: Expanded git conventions — branch examples, commit wording, signing
+alwaysApply: false
+globs:
+  - ".cursor/rules/git-conventions.mdc"
+  - ".cursor/rules/git-conventions.detail.mdc"
+  - "AGENTS.md"
+  - ".cursor/environment.json"
+  - ".github/**/*.yml"
+---
+
+# Git conventions (detail)
+
+Follow these rules for git operations in this repository (local work, Cursor agents, and CI-related branches unless a maintainer overrides for automation).
+
+## Branch names
+
+Use this format only:
+
+`<type>/<content>-<date>`
+
+- **`type`**: Short category for the change (examples: `feature`, `fix`, `chore`, `refactor`; pick the closest match).
+- **`content`**: Brief, hyphenated slug describing the work (lowercase ASCII, avoid spaces).
+- **`date`**: Six digits **`YYMMDD`** (example: `260423` for 2026-04-23).
+
+Examples:
+
+- `feature/add-metrics-260423`
+- `fix/nil-pointer-parser-260423`
+- `chore/update-ci-260423`
+
+Do **not** use other prefixes (for example `cursor/` unless the team explicitly adopts them).
+
+## Commit messages
+
+1. Write messages that describe **only** the code change (what and why in plain language). No marketing or tool attribution.
+2. Do **not** include phrases such as **"Made with Cursor"**, **"Made with Codex"**, or similar agent/product footers anywhere in the subject or body.
+
+## Signed commits
+
+Commits **must** be cryptographically signed.
+
+- Prefer **SSH signing** (`git config gpg.format ssh` + `user.signingkey`) or **GPG signing** as documented in Git’s “Signing commits” guides.
+- Use `git commit -S` (capital S) when committing.
+
+If signing is not configured on a machine, configure it before pushing; do not bypass this requirement with `--no-gpg-sign` unless a repository maintainer explicitly allows an exception for a given automation path.

--- a/.cursor/rules/git-conventions.mdc
+++ b/.cursor/rules/git-conventions.mdc
@@ -1,40 +1,12 @@
 ---
-description: Branch naming, commit messages, and signing requirements for git work in this repo
+description: Git branches, commits, and signing — always-on summary for this repo
 alwaysApply: true
 ---
 
-# Git conventions
+# Git conventions (summary)
 
-Follow these rules for **every** git operation in this repository (local work, Cursor agents, and CI-related branches unless a maintainer overrides for automation).
+- **Branches**: use `<type>/<content>-<date>` only — **`type`** is `feature`, `fix`, `chore`, `refactor`, etc.; **`content`** is a short hyphenated slug; **`date`** is six digits **`YYMMDD`** (e.g. `260423`).
+- **Commits**: describe **only** the code change. Do **not** add lines like **“Made with Cursor”**, **“Made with Codex”**, or other agent/product footers.
+- **Signing**: commits **must** be signed — use **`git commit -S`** and configure SSH or GPG signing as in Git’s docs.
 
-## Branch names
-
-Use this format only:
-
-`<type>/<content>-<date>`
-
-- **`type`**: Short category for the change (examples: `feature`, `fix`, `chore`, `refactor`; pick the closest match).
-- **`content`**: Brief, hyphenated slug describing the work (lowercase ASCII, avoid spaces).
-- **`date`**: Six digits **`YYMMDD`** (example: `260423` for 2026-04-23).
-
-Examples:
-
-- `feature/add-metrics-260423`
-- `fix/nil-pointer-parser-260423`
-- `chore/update-ci-260423`
-
-Do **not** use other prefixes (for example `cursor/` unless the team explicitly adopts them).
-
-## Commit messages
-
-1. Write messages that describe **only** the code change (what and why in plain language). No marketing or tool attribution.
-2. Do **not** include phrases such as **"Made with Cursor"**, **"Made with Codex"**, or similar agent/product footers anywhere in the subject or body.
-
-## Signed commits
-
-Commits **must** be cryptographically signed.
-
-- Prefer **SSH signing** (`git config gpg.format ssh` + `user.signingkey`) or **GPG signing** as documented in Git’s “Signing commits” guides.
-- Use `git commit -S` (capital S) when committing.
-
-If signing is not configured on a machine, configure it before pushing; do not bypass this requirement with `--no-gpg-sign` unless a repository maintainer explicitly allows an exception for a given automation path.
+For examples, anti-patterns, and signing setup notes, see **`.cursor/rules/git-conventions.detail.mdc`** (it attaches when you edit those git/CI-related paths).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,10 @@
 - Keep rules minimal, practical, and easy to enforce in daily work.
 - If a more specific rule (package-level doc, directory-level `AGENTS.md`, or explicit user instruction) conflicts with this document, the more specific rule wins.
 
+## Git branches and commits
+
+A short always-on summary lives in `.cursor/rules/git-conventions.mdc`; full wording and examples are in `.cursor/rules/git-conventions.detail.mdc`.
+
 ## Style And Formatting
 - Always format code with `gofmt -s` (or `go fmt ./...`) and make sure `go vet ./...` is clean before committing.
 - Use clear, intention-revealing names; avoid abbreviations unless they are standard in Go.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Restores **alwaysApply: true** for git conventions without loading the full long rule on every conversation:

- **`.cursor/rules/git-conventions.mdc`** — short summary (branch format, no agent footers in commits, signed commits); **`alwaysApply: true`**.
- **`.cursor/rules/git-conventions.detail.mdc`** — prior full text (examples, signing notes); **`alwaysApply: false`** + **`globs`** so it attaches when editing git/CI-related paths or either rule file.

Updates **`AGENTS.md`** with pointers to both files.

## Verification

`go vet ./...`, `go test ./...`, `go build ./...`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a3f7f67a-348f-465e-bd73-c47fdbf186d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a3f7f67a-348f-465e-bd73-c47fdbf186d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

