### PR TITLE
docs(manager): design and subsystem AGENTS/PLAN

### DIFF
--- a/pkg/manager/AGENTS.md
+++ b/pkg/manager/AGENTS.md
@@ -1,0 +1,71 @@
+# pkg/manager AGENTS.md
+
+## Scope
+
+`pkg/manager` is the workspace **lifecycle plane**. It owns the catalog
+of Plugins, the registry of Agent specs and Infra factories, and the
+repository of Workspaces. It bootstraps agent programs inside infras,
+attaches plugins, persists workspace records, and drives a periodic
+liveness probe.
+
+This package depends on the standard library plus its own subpackages.
+It is consumed by the host binary's assembly code (e.g., `cmd/ana/...`)
+and is **decoupled from the orchestrator**: it MUST NOT import
+`pkg/agentio` or `pkg/orchestrator/...`. Integration with the
+orchestrator happens in operator code that reads workspace records and
+synthesizes `agentio.Agent` factories from the agent's
+`ProtocolDescriptor`.
+
+## Authoritative documents
+
+- `DESIGN.md` (this directory) — the comprehensive design and the
+  source of truth for cross-module decisions. Any change to the
+  workspace state machine, the Plugin/Workspace data model, the
+  InfraOps method set, the AgentSpec contract, or the
+  manager-orchestrator boundary MUST update `DESIGN.md` first.
+- Per-module `PLAN.md` files — module-level details (interfaces, data
+  shapes, edge cases). They MUST stay consistent with `DESIGN.md`.
+
+If a module needs to deviate from `DESIGN.md`, update `DESIGN.md` in
+the same change.
+
+## Module conventions
+
+- Every subpackage is small and exports a focused interface plus a
+  default reference implementation when one is shipped.
+- Subpackages follow the dependency graph in `DESIGN.md` §12.1. Adding
+  a new edge requires updating that section.
+- Cross-module integration tests live in this directory (root package),
+  not in subpackages, to avoid circular references.
+- Identifier types (`PluginID`, `WorkspaceID`, `Namespace`, `Alias`,
+  `AgentType`, `InfraType`) are aliases over `string` declared in
+  `types.go`. Use the named types at function signatures; raw strings
+  are reserved for serialization boundaries.
+
+## Naming
+
+- Logger keys: `op`, `component`, `workspace_id`, `workspace_alias`,
+  `namespace`, `agent_type`, `infra_type`, `plugin_id`, `latency_ms`,
+  `err`. New keys require updating `DESIGN.md` §9.1.
+- Sentinel errors: `ErrPluginNotFound`, `ErrWorkspaceNotFound`,
+  `ErrAliasConflict`, `ErrAgentTypeUnknown`, `ErrInfraTypeUnknown`,
+  `ErrShutdown`, `ErrInstallTimeout`, etc. Owned by the originating
+  subpackage; the root package wraps them with operation context using
+  `fmt.Errorf("<manager op>: %w", err)`.
+
+## Things to avoid
+
+- No transitive import of `pkg/agentio` or `pkg/orchestrator/...`. The
+  manager is decoupled from the runtime control plane by design (see
+  `DESIGN.md` §11). Adapter code lives in operator binaries, not here.
+- No silent retries on install. A failed install moves the workspace to
+  `failed` with a structured error; the operator decides whether to
+  delete and recreate.
+- No background work outside the documented loops (install worker pool,
+  probe scheduler). New goroutines require a Builder option and a
+  shutdown path through `Stop`.
+- No reading or writing of secrets in this package. `InstallParams` and
+  `InfraOptions` are stored verbatim and never logged at value level.
+- No reach-around imports between subpackages. `agent/` does not see
+  `workspace/`; `infraops/` does not see `agent/`. Stay inside the
+  layered graph.

--- a/pkg/manager/DESIGN.md
+++ b/pkg/manager/DESIGN.md
@@ -1,0 +1,1076 @@
+# ANA Manager Design
+
+> **Status:** v1 design, no implementation yet. Implementation tasks should
+> follow the per-module `PLAN.md` files together with this document.
+>
+> **Audience:** ANA contributors implementing or extending the workspace
+> management plane.
+
+## 1. Background & Goals
+
+ANA is an agent orchestration system. The orchestrator (`pkg/orchestrator`)
+is the runtime control plane that routes user input through a tree of
+workspaces and produces a final answer. Before a workspace can be routed
+to, somebody has to **provision** it: pick an agent program (Claude Code,
+OpenClaw, …), drop the right plugins into the right directories, install
+the program, optionally start a long-running gateway, give the workspace a
+human-readable alias, and persist enough state to find it again later.
+That provisioning lifecycle is the job of `pkg/manager`.
+
+`pkg/manager` is the workspace **lifecycle plane**. It owns:
+
+- A catalog of **Plugins** (zip packages of skills/rules/hooks/subagents)
+  with pluggable storage and a manifest format we control.
+- A registry of **Agent specs** (interface implementations describing how
+  to install, configure, probe, and reach a particular kind of agent
+  program).
+- A registry of **InfraOps factories** (interface implementations
+  describing how to perform atomic file/exec/network operations against a
+  particular kind of execution environment — local directory, Docker
+  container, E2B sandbox, etc.).
+- A repository of **Workspaces** — concrete agent instances bootstrapped
+  inside an infra, attached to plugins, and tracked by status with a
+  liveness probe.
+
+The manager is **decoupled** from the orchestrator: it does not import
+`pkg/agentio` or `pkg/orchestrator/...`. The application assembly layer
+that builds the binary is the only place that bridges the two planes
+(typically by reading a manager `Workspace` plus its `AgentSpec`'s
+protocol descriptor and synthesizing an `agentio.Agent` factory for the
+orchestrator's `registry`). This boundary is documented in §11.
+
+### 1.1 Goals
+
+- One vocabulary (Agent, Plugin, Workspace, Infra) used consistently
+  across the package and its module docs.
+- Pluggable backends for each capability (DB, plugin storage, infra
+  type, agent type) so deployments can swap implementations.
+- A small, documented file format for plugin packages so users can build
+  plugins by hand or with tooling without reading code.
+- Asynchronous workspace provisioning with an observable status machine
+  (`init` / `healthy` / `failed`) and a built-in liveness probe loop.
+- Crash-safe operations: every state transition that the user can
+  observe is persisted before any side effect that the user cannot
+  reverse.
+- A clear extension surface (`AgentSpec`, `infraops.Factory`,
+  `PluginStorage`, `Repository` interfaces) so adding a new agent type
+  or a new infra type is a localized change.
+- A registration API that lets a future component (orchestrator
+  registry, scheduler, dashboard) consume manager state without
+  reaching into internals.
+
+### 1.2 Non-Goals (v1)
+
+- No multi-node coordination. A manager instance owns its database; if
+  you want HA you front it with a SQL backend and run a single writer.
+  Cross-instance coordination is v2.
+- No plugin **versioning**. A plugin is identified by a stable ID; new
+  uploads overwrite the stored zip; previously-attached workspaces are
+  unaffected because they extracted their content at attach time.
+- No automatic plugin upgrade for existing workspaces. The user
+  re-creates a workspace (or runs a re-attach flow that we deliberately
+  defer to v2).
+- No multi-tenancy isolation beyond namespacing of workspace aliases and
+  plugin names. Authentication, authorization, and quota are out of
+  scope.
+- No general-purpose secret store. Workspace creation may take secrets
+  through `infraops.Options` or `AgentSpec.InstallParams`, but the
+  manager neither stores nor rotates them.
+- No retention or GC of audit / log artifacts. The manager records
+  status; logs are emitted via `log/slog` and consumed by the
+  deployment.
+- No long-running orchestration of agent **runs**. Driving an agent
+  through a task is the orchestrator's job; the manager only ensures the
+  workspace is reachable.
+
+## 2. Concepts & Vocabulary
+
+### 2.1 Agent
+
+An **Agent** is the metadata that describes a *kind* of agent program:
+its identifier (e.g., `claude-code`, `openclaw`), its display name, the
+recipe to install it inside an `InfraOps`-shaped environment, the recipe
+to lay plugin contents into the agent's expected directory structure,
+the liveness probe routine, and a structured **protocol descriptor**
+that downstream consumers (e.g., the orchestrator) read to learn how to
+talk to a workspace built from this Agent.
+
+In this codebase Agent is represented by the `agent.AgentSpec` interface
+(see `agent/PLAN.md`). The manager keeps an in-memory map keyed by
+`Type()` (the agent type id) populated through `Builder.RegisterAgentSpec`.
+Workspaces persist `agent_type` so the controller can find the spec
+again on restart.
+
+> Disambiguation: `pkg/manager/agent` is **not** `pkg/agentio`. The
+> former describes how to bring an agent program *into existence inside
+> an infra*; the latter is the canonical request/event contract used at
+> *invocation time*. The two planes meet only in application assembly
+> code.
+
+### 2.2 Plugin
+
+A **Plugin** is a packaged collection of agent-portable resources
+(skills, rules, hooks, subagents, MCP configs, AGENTS.md, …) stored as a
+zip file with a small manifest. Plugins are agent-agnostic in their
+on-disk layout: `skills/`, `rules/`, `hooks/`, etc. Each `AgentSpec`
+declares a `PluginLayout` that maps the canonical layout onto the
+agent's specific filesystem expectations (for example, Claude Code
+expects `~/.claude/plugins/<plugin-name>/skills/...`).
+
+Plugins live in two places:
+
+- **Plugin metadata** in the manager database (id, name, description,
+  size, content hash, attached count, timestamps).
+- **Plugin content** in a `PluginStorage` backend (default: local
+  directory; extensible to S3, GCS, …) keyed by plugin id.
+
+See `plugin/PLAN.md` for the manifest format, on-disk layout, and the
+`PluginStorage` and `PluginRepository` interfaces.
+
+### 2.3 Workspace
+
+A **Workspace** is a concrete instantiation of an Agent inside an Infra,
+optionally with a set of attached Plugins, identified by a globally
+unique opaque id and a human-readable alias scoped within a namespace.
+
+A workspace owns:
+
+- `WorkspaceID` — opaque, manager-generated, stable.
+- `Namespace` — string (default: `"default"`). Aliases collide only
+  within a namespace.
+- `Alias` — human-friendly, namespace-scoped, immutable.
+- `AgentType` — the registered `AgentSpec.Type()`; pins the workspace
+  to one agent kind for life.
+- `InfraType` — the registered infra type; pins the workspace to one
+  infra kind for life.
+- `InfraOptions` — opaque-to-manager bag persisted verbatim, used to
+  reconstruct an `InfraOps` instance whenever the controller needs to
+  touch the workspace (probe, delete, etc.).
+- `Plugins []AttachedPlugin` — snapshot of which plugins were attached
+  at creation time and where they were placed (see §6.5).
+- `Status` — `init`, `healthy`, `failed` (state machine in §5).
+- `LastProbeAt`, `LastError`, `CreatedAt`, `UpdatedAt`, …
+
+Workspaces **never share** an alias within a namespace, never change
+their `AgentType` or `InfraType`, and never rebuild plugins on demand.
+"Update" is "delete + create" with the same alias.
+
+### 2.4 Infra
+
+An **Infra** is the runtime environment a workspace lives in. The
+manager treats infras as opaque file-and-process surfaces accessed
+through the `infraops.InfraOps` interface (§7). v1 ships one
+implementation, `infraops/localdir`, that targets a local directory on
+the host running the manager. Future implementations (Docker, E2B,
+serverless) plug in through the same interface.
+
+`InfraOps` instances are created on demand. The manager does **not**
+keep a long-lived `InfraOps` per workspace; instead it constructs one
+each time it needs to act, using the persisted `InfraType` +
+`InfraOptions`. This keeps state small and crash-safe.
+
+### 2.5 Manager
+
+The **Manager** is the public façade — one Go interface that the host
+binary depends on. It owns:
+
+- A `PluginRepository` (database) and a `PluginStorage` (blob backend)
+  that together back the Plugin CRUD API.
+- A `WorkspaceRepository` that backs the Workspace CRUD API.
+- A `Clock` and `IDGenerator` (injected for testability).
+- An immutable `agentSpecs` registry built from `RegisterAgentSpec`.
+- An immutable `infraFactories` registry built from `RegisterInfraType`.
+- A background **probe scheduler** that periodically calls
+  `AgentSpec.Probe` on every active workspace.
+- A logger (`*slog.Logger`) for observability.
+
+The Manager exposes:
+
+- Plugin CRUD (`CreatePlugin`, `GetPlugin`, `ListPlugins`,
+  `DeletePlugin`, `GetPluginDownloadURL`).
+- Infra factory access (`NewInfraOps`).
+- Workspace CRUD + lifecycle
+  (`CreateWorkspace`, `GetWorkspace`, `GetWorkspaceByAlias`,
+  `ListWorkspaces`, `DeleteWorkspace`).
+- Process lifecycle (`Start`, `Stop`) for the probe scheduler.
+
+### 2.6 Namespace
+
+A **Namespace** is a labeling string (default `"default"`) that scopes
+**workspace alias** and **plugin name** uniqueness. Namespaces are
+declarative: there is no "create namespace" API; a namespace exists by
+virtue of having a row in the workspace or plugin repository. v1 does
+not enforce ACLs across namespaces; the namespace is a soft partition
+useful for organizing tenants or environments.
+
+## 3. Public API (Sketch)
+
+Concrete Go signatures are settled in code; the shape below is fixed.
+
+```go
+package manager
+
+type Manager interface {
+    // Plugin CRUD
+    CreatePlugin(ctx context.Context, req CreatePluginRequest) (Plugin, error)
+    GetPlugin(ctx context.Context, id PluginID) (Plugin, error)
+    GetPluginByName(ctx context.Context, namespace Namespace, name string) (Plugin, error)
+    ListPlugins(ctx context.Context, opts ListPluginsOptions) (rows []Plugin, nextCursor string, err error)
+    DeletePlugin(ctx context.Context, id PluginID) error
+    GetPluginDownloadURL(ctx context.Context, id PluginID, opts DownloadURLOptions) (string, error)
+
+    // Infra factory
+    NewInfraOps(ctx context.Context, infraType InfraType, options infraops.Options) (infraops.InfraOps, error)
+    InfraTypes() []InfraType
+
+    // Workspace CRUD + lifecycle
+    CreateWorkspace(ctx context.Context, req CreateWorkspaceRequest) (Workspace, error)
+    GetWorkspace(ctx context.Context, id WorkspaceID) (Workspace, error)
+    GetWorkspaceByAlias(ctx context.Context, namespace Namespace, alias Alias) (Workspace, error)
+    ListWorkspaces(ctx context.Context, opts ListWorkspacesOptions) (rows []Workspace, nextCursor string, err error)
+    DeleteWorkspace(ctx context.Context, id WorkspaceID) error
+    AgentTypes() []AgentType
+
+    // Process lifecycle
+    Start(ctx context.Context) error
+    Stop(ctx context.Context) error
+}
+```
+
+The constructor takes a `Builder` so all collaborators are explicit and
+swappable in tests:
+
+```go
+type Builder struct {
+    // immutable backends (required)
+    PluginRepository    plugin.Repository
+    PluginStorage       plugin.Storage
+    WorkspaceRepository workspace.Repository
+
+    // optional collaborators (defaults provided)
+    Clock        func() time.Time
+    IDGenerator  IDGenerator   // see §6.8
+    Logger       *slog.Logger
+
+    // install worker tuning (optional)
+    InstallTimeout time.Duration // default 10 min
+    InstallWorkers int           // default 4
+
+    // probe scheduler tuning (optional)
+    ProbeInterval time.Duration  // default 30 s
+    ProbeWorkers  int            // default 4
+    ProbeTimeout  time.Duration  // default 5 s
+
+    // registered extensions (populated via RegisterAgentSpec / RegisterInfraType)
+    // unexported fields, mutated by the methods below
+}
+
+func NewBuilder() *Builder
+func (b *Builder) RegisterAgentSpec(spec agent.AgentSpec) *Builder
+func (b *Builder) RegisterInfraType(infraType InfraType, factory infraops.Factory) *Builder
+func (b *Builder) Build() (Manager, error)
+```
+
+`Build()` returns an error if:
+
+- a required backend is nil,
+- two `AgentSpec` values declare the same `Type()`,
+- two infra factories share the same `infraType`.
+
+A manager with zero registered agent types or zero registered infra
+types is allowed (a "plugin-only" manager that just hosts the plugin
+catalog still validates) but emits `slog.Warn` so the operator can spot
+misconfiguration.
+
+The `Builder` is **single-use**: `Build()` consumes it. Re-using the
+builder after `Build` returns is an error.
+
+## 4. End-to-End Walkthrough
+
+The canonical flows ground the abstractions. Triples in the form
+`(workspace_id, agent_type, infra_type)` accompany each step.
+
+### 4.1 Upload a plugin
+
+```
+User → Manager.CreatePlugin({
+    Namespace: "default",
+    Name:      "trading-research",
+    Description: "Stock-research skills + hooks",
+    Content:   <io.Reader of plugin.zip>,
+})
+
+Manager validates the manifest (manifest.toml at the zip root, see §6.4),
+computes a content hash, asks PluginStorage.Put(planned_id, body) to
+store the bytes, and inserts a Plugin row in PluginRepository.
+
+Result: Plugin{ID, Namespace, Name, ContentHash, Size, ...}.
+```
+
+### 4.2 Provision a workspace
+
+```
+User → Manager.CreateWorkspace({
+    Namespace: "default",
+    Alias:     "Alice",
+    AgentType: "claude-code",
+    InfraType: "localdir",
+    InfraOptions: infraops.Options{
+        "dir": "/var/lib/ana/workspaces/alice",
+    },
+    Plugins: []PluginRef{
+        {ID: "plg-trading-research"},
+    },
+    InstallParams: map[string]any{
+        "claude_binary": "/usr/local/bin/claude",
+    },
+})
+
+1. Manager validates: namespace+alias unused, agent_type registered,
+   infra_type registered, plugin ids exist in repo.
+2. Manager allocates WorkspaceID, persists Workspace{Status: init} to
+   WorkspaceRepository in one transaction.
+3. Manager dispatches the install to a worker goroutine and returns the
+   in-flight Workspace to the caller. The caller polls Get* to observe
+   status.
+4. Worker:
+   a. Constructs InfraOps via infraops.Factory(infraOptions).
+   b. Calls InfraOps.Init() — guarantees an empty working directory.
+   c. Resolves AgentSpec by AgentType.
+   d. For each PluginRef: PluginStorage.Get(id) → io.ReadCloser; the
+      worker streams the zip into AgentSpec.PluginLayout().Apply(ops, ...)
+      which writes files via InfraOps.PutFile(...) into the agent's
+      expected paths.
+   e. Calls AgentSpec.Install(ctx, ops, InstallParams) which installs
+      the agent program (e.g., copies the binary, writes a config
+      file) and, if applicable, starts the daemon process.
+   f. Calls AgentSpec.Probe(ctx, ops) once to confirm.
+   g. On success: WorkspaceRepository.UpdateStatus(id, healthy).
+   h. On error at any step: WorkspaceRepository.UpdateStatus(id, failed)
+      with the error message and code; the working directory is left in
+      place for diagnosis (cleanup happens at delete time).
+
+The probe scheduler picks the workspace up at the next tick and keeps
+status in sync going forward.
+```
+
+### 4.3 Probe loop
+
+```
+Every ProbeInterval (default 30s):
+  for each workspace in WorkspaceRepository.ListByStatus(healthy|failed):
+      ops    := factory(workspace.InfraOptions)
+      result := AgentSpec.Probe(ctx, ops)
+      newStatus := healthy if result.Healthy else failed
+      if newStatus != workspace.Status:
+          WorkspaceRepository.UpdateStatus(workspace.ID, newStatus, result.Error)
+
+The scheduler uses a worker pool (ProbeWorkers, default 4). Workspaces
+in init are skipped — the install worker owns them.
+```
+
+### 4.4 Delete a workspace
+
+```
+User → Manager.DeleteWorkspace(workspace_id)
+
+1. Manager loads the Workspace; if not found, returns ErrWorkspaceNotFound.
+2. Reconstructs InfraOps via factory(workspace.InfraOptions).
+3. Calls AgentSpec.Uninstall(ctx, ops) to stop any daemons cleanly
+   (best-effort; errors logged but continue).
+4. Calls InfraOps.Clear(ctx) to drop the working directory.
+5. WorkspaceRepository.Delete(workspace_id).
+6. Returns success even if step 3 or 4 emitted recoverable errors,
+   provided step 5 succeeded; partial cleanup is reported through the
+   logger.
+
+Idempotent: deleting a non-existent workspace returns
+ErrWorkspaceNotFound without side effects.
+```
+
+### 4.5 Delete a plugin
+
+```
+User → Manager.DeletePlugin(plugin_id)
+
+1. PluginRepository.Get(plugin_id) → Plugin or ErrPluginNotFound.
+2. PluginStorage.Delete(plugin_id) → removes the zip from the backend.
+3. PluginRepository.Delete(plugin_id) → removes the metadata row.
+
+Workspaces that previously attached this plugin keep their on-disk
+plugin files (the manager does not enforce referential integrity at
+delete). The workspace metadata still records AttachedPlugin{ID:...},
+which is now a dangling reference; consumers must tolerate this.
+```
+
+## 5. State Machines
+
+### 5.1 Workspace
+
+```
+                ┌──────┐
+CreateWorkspace │ init │
+        ────────▶      │
+                └──┬───┘
+                   │ install worker succeeds
+                ┌──▼─────┐
+                │healthy │◀─── probe ok
+                └──┬─────┘
+                   │ probe / install fail
+                   ▼
+                ┌──────┐
+                │failed│ ◀─── probe still failing
+                └──┬───┘
+                   │ probe ok
+                   └──▶ healthy
+```
+
+Terminal: workspaces never reach a terminal state at the data layer;
+"deleted" is the absence of the row. Cancellation in the install worker
+flips `init → failed` if the operator cancels the manager while a
+workspace is being created.
+
+`init` is special:
+
+- Newly persisted state right after `CreateWorkspace` returns to the
+  caller.
+- Skipped by the probe scheduler (the install worker is the only writer).
+- A workspace stuck in `init` for longer than `InstallTimeout`
+  (configurable, default 10 minutes) is force-flipped to `failed` by
+  the probe scheduler with `ErrInstallTimeout`. This protects against
+  install-worker crashes.
+
+### 5.2 Plugin
+
+Plugins have no status machine. They exist or they do not. Uploading a
+new zip with the same `(namespace, name)` overwrites the row and the
+content (atomic at the manager level); see §10.2 for the concurrency
+contract.
+
+## 6. Core Data Model
+
+This section is the cross-module source of truth for field names. Each
+module may add internal fields but MUST NOT rename or repurpose those
+listed below.
+
+### 6.1 Identifier types
+
+| Type             | Shape                            | Notes |
+|------------------|----------------------------------|-------|
+| `PluginID`       | string                           | Opaque; generated by manager. Convention: `plg_<base32>`. |
+| `WorkspaceID`    | string                           | Opaque. Convention: `wsp_<base32>`. |
+| `Namespace`      | string                           | `[a-z0-9-]{1,32}`. Default `"default"`. |
+| `Alias`          | string                           | `[A-Za-z][A-Za-z0-9_-]{0,63}`. |
+| `AgentType`      | string                           | Lowercase kebab. Owned by `AgentSpec.Type()`. |
+| `InfraType`      | string                           | Lowercase kebab. Owned by registration. |
+
+All ID types are aliases over `string` declared in
+`pkg/manager/types.go` to keep call sites readable.
+
+### 6.2 `Plugin`
+
+| Field         | Type        | Notes |
+|---------------|-------------|-------|
+| `ID`          | `PluginID`  | Primary key. |
+| `Namespace`   | `Namespace` | Scope for `Name` uniqueness. |
+| `Name`        | `string`    | Unique within namespace. `[a-z0-9-]{1,64}`. |
+| `Description` | `string`    | ≤ 1024 chars. Free-form. |
+| `Manifest`    | `plugin.Manifest` | Structured copy of `manifest.toml`. |
+| `ContentHash` | `string`    | `sha256:<hex>` of the zip body. |
+| `Size`        | `int64`     | Bytes. |
+| `CreatedAt`   | `time.Time` | UTC. |
+| `UpdatedAt`   | `time.Time` | UTC. |
+
+The full structure of `Manifest` lives in `plugin/PLAN.md` §Manifest.
+
+### 6.3 `Workspace`
+
+| Field             | Type                   | Notes |
+|-------------------|------------------------|-------|
+| `ID`              | `WorkspaceID`          | Primary key. |
+| `Namespace`       | `Namespace`            | Scope for `Alias` uniqueness. |
+| `Alias`           | `Alias`                | Immutable; namespace-unique. |
+| `AgentType`       | `AgentType`            | Immutable. |
+| `InfraType`       | `InfraType`            | Immutable. |
+| `InfraOptions`    | `infraops.Options`     | Persisted as JSON; opaque to manager. |
+| `InstallParams`   | `map[string]any`       | Persisted as JSON; opaque to manager; consumed by `AgentSpec.Install`. |
+| `Plugins`         | `[]AttachedPlugin`     | Snapshot at creation time. |
+| `Status`          | `WorkspaceStatus`      | `init` / `healthy` / `failed`. |
+| `StatusError`     | `*WorkspaceError`      | Non-nil when `Status == failed` or transient install error. |
+| `Description`     | `string`               | Free-form, ≤ 1024 chars. |
+| `Labels`          | `map[string]string`    | Optional user labels for ListWorkspaces filtering. |
+| `LastProbeAt`     | `time.Time`            | Zero until first probe completes. |
+| `CreatedAt`       | `time.Time`            | UTC. |
+| `UpdatedAt`       | `time.Time`            | UTC. |
+
+Secrets in `InstallParams` and `InfraOptions`: these maps are stored
+verbatim by the repository. Operators that handle secret material
+choose a repository implementation that encrypts at rest, or supply
+references (e.g., `{"vault_path":"…"}`) instead of inline secrets. The
+manager logger NEVER logs option/param values — only their keys (see
+§9).
+
+### 6.4 `WorkspaceError`
+
+| Field      | Type     | Notes |
+|------------|----------|-------|
+| `Code`     | `string` | Machine-friendly. e.g. `install.exec_failed`, `probe.unhealthy`. |
+| `Message`  | `string` | Human-readable. |
+| `Phase`    | `string` | `install`, `probe`, `uninstall`. |
+| `RecordedAt` | `time.Time` |  |
+
+### 6.5 `AttachedPlugin`
+
+| Field          | Type        | Notes |
+|----------------|-------------|-------|
+| `PluginID`     | `PluginID`  | Reference to `Plugin`; may dangle after the plugin is deleted. |
+| `Name`         | `string`    | Plugin name at attach time, captured for diagnostic display. |
+| `ContentHash`  | `string`    | Plugin content hash at attach time. |
+| `PlacedPaths`  | `[]string`  | Paths inside the workspace dir that received plugin files (relative to `InfraOps.Dir()`). |
+
+`AttachedPlugin` is a snapshot. Re-attaching a plugin to an existing
+workspace is not supported in v1 (see §1.2); replacements go through
+delete-and-recreate.
+
+### 6.6 Request shapes
+
+```go
+type CreatePluginRequest struct {
+    Namespace   Namespace
+    Name        string
+    Description string
+    Content     io.Reader   // exactly the zip body
+}
+
+type ListPluginsOptions struct {
+    Namespace Namespace // empty: all namespaces
+    NameLike  string    // optional substring match on Name
+    Limit     int
+    Cursor    string    // opaque pagination cursor
+}
+
+type DownloadURLOptions struct {
+    TTL time.Duration // optional; defaults to PluginStorage default
+}
+
+type CreateWorkspaceRequest struct {
+    Namespace     Namespace
+    Alias         Alias
+    AgentType     AgentType
+    InfraType     InfraType
+    InfraOptions  infraops.Options
+    InstallParams map[string]any
+    Plugins       []PluginRef
+    Description   string
+    Labels        map[string]string
+}
+
+type PluginRef struct {
+    ID PluginID
+}
+
+type ListWorkspacesOptions struct {
+    Namespace Namespace
+    AgentType AgentType
+    InfraType InfraType
+    Status    WorkspaceStatus
+    Labels    map[string]string
+    Limit     int
+    Cursor    string
+}
+```
+
+### 6.7 `WorkspaceStatus`
+
+```go
+type WorkspaceStatus string
+
+const (
+    StatusInit    WorkspaceStatus = "init"
+    StatusHealthy WorkspaceStatus = "healthy"
+    StatusFailed  WorkspaceStatus = "failed"
+)
+```
+
+### 6.8 `IDGenerator`
+
+```go
+type IDGenerator interface {
+    PluginID() PluginID
+    WorkspaceID() WorkspaceID
+}
+```
+
+The default implementation produces opaque base32 ids prefixed with
+`plg_` and `wsp_` respectively, seeded by `crypto/rand`. Tests inject
+deterministic generators. The package does NOT mint other id types
+here — `EventID`, `RequestID`, etc. belong to the orchestrator and
+are not part of the manager surface.
+
+## 7. InfraOps Contract
+
+The full specification lives in `infraops/PLAN.md`; this section fixes
+the cross-module shape and the v1 method set.
+
+### 7.1 v1 method set
+
+```go
+type InfraOps interface {
+    // Type returns the infra type id (e.g., "localdir").
+    Type() string
+    // Dir returns the absolute working directory inside the infra.
+    Dir() string
+
+    // Init prepares the working directory. After a successful Init,
+    // Dir() exists and is empty. Calling Init on an already-initialized
+    // dir returns ErrAlreadyInitialized.
+    Init(ctx context.Context) error
+
+    // Exec runs a structured command relative to Dir(). Stdout/Stderr
+    // are buffered into ExecResult unless the caller supplies streamers
+    // on ExecCommand.
+    Exec(ctx context.Context, cmd ExecCommand) (ExecResult, error)
+
+    // PutFile writes `path` (relative to Dir()) with `content`.
+    // Intermediate directories are created.
+    PutFile(ctx context.Context, path string, content io.Reader, mode fs.FileMode) error
+
+    // GetFile reads `path` (relative to Dir()) as a stream.
+    GetFile(ctx context.Context, path string) (io.ReadCloser, error)
+
+    // Request opens an HTTP-shaped channel to a daemon listening on
+    // `port` inside the infra. Implementations translate `port` into
+    // a host:port reachable from the manager process (e.g., the local
+    // loopback for localdir; published ports for Docker; tunneled URLs
+    // for E2B). Caller closes the response body.
+    Request(ctx context.Context, port int, req *http.Request) (*http.Response, error)
+
+    // Clear drops the working directory and any infra-side resources
+    // (containers, sandboxes, …). Idempotent.
+    Clear(ctx context.Context) error
+}
+```
+
+`ExecCommand` and `ExecResult` are defined in `infraops/PLAN.md`. The
+shape is fixed: program + args + env + stdin + optional stdout/stderr
+writers, plus a working-directory override relative to `Dir()`.
+
+### 7.2 Why these methods
+
+- **Why structured `Exec` (no shell string)?** Eliminates injection.
+  Implementations that ride a shell on the other side (Docker, SSH)
+  quote the args. Callers that need shell features pass
+  `Program: "sh", Args: []string{"-c", "..."}` deliberately.
+- **Why explicit `PutFile`/`GetFile`?** Binary-safe transfer is
+  required for plugin zips and CLI binaries. Encoding through `Exec`
+  has been tried elsewhere; it always regrets.
+- **Why HTTP-shaped `Request` (instead of WS / arbitrary TCP)?** The
+  v1 agent set runs HTTP-style gateways. Adding a `Dial(port)
+  (net.Conn, error)` for socket / WS support is a backward-compatible
+  extension.
+- **Why no `Stat`/`Remove`/`Mkdir`?** They're consequences of
+  `Exec("test", ...)`, `Exec("rm", ...)`, etc. on the platforms we
+  support, and `PutFile` already creates intermediate directories.
+  Future infras that benefit from native directory operations can add
+  them as an extension interface checked via type assertion.
+
+### 7.3 Options & Factory
+
+```go
+type Options map[string]any   // JSON-serializable
+
+type Factory func(ctx context.Context, opts Options) (InfraOps, error)
+```
+
+Required option for every infra: `"dir"` — the absolute working
+directory. Implementations document additional keys in their own
+`PLAN.md`. The manager validates only that `dir` is non-empty before
+calling the factory; the factory validates everything else and returns
+typed errors.
+
+The factory is invoked in three situations:
+
+1. `Manager.NewInfraOps` — caller-driven, for ad-hoc operations.
+2. Workspace install worker — once per provisioning.
+3. Probe scheduler — once per probe tick per workspace.
+
+Therefore factories MUST be cheap to call (do real work in `Init`, not
+in the constructor).
+
+## 8. AgentSpec Contract
+
+Specification lives in `agent/PLAN.md`; cross-module surface fixed
+here.
+
+### 8.1 Interface shape
+
+```go
+type AgentSpec interface {
+    Type() AgentType
+    DisplayName() string
+    Description() string
+
+    // PluginLayout returns the strategy that maps canonical plugin
+    // contents into agent-specific paths inside an InfraOps.
+    PluginLayout() PluginLayout
+
+    // Install bootstraps the workspace inside ops. Steps are
+    // implementation-defined but MUST be idempotent so the install
+    // worker can resume from any post-PutFile state if it crashes.
+    // Install MAY start long-running processes (gateway, daemons);
+    // CLI-style agents typically do not.
+    Install(ctx context.Context, ops infraops.InfraOps, params InstallParams) error
+
+    // Uninstall stops anything Install started. Best-effort.
+    // Errors are logged but do not abort delete.
+    Uninstall(ctx context.Context, ops infraops.InfraOps) error
+
+    // Probe checks that a previously-installed workspace is reachable.
+    // Probe MUST NOT mutate state.
+    Probe(ctx context.Context, ops infraops.InfraOps) (ProbeResult, error)
+
+    // ProtocolDescriptor returns a structured description of the
+    // workspace's invocation surface. Consumers (e.g., orchestrator
+    // assembly code) read this to construct an agentio.Agent
+    // factory. The manager itself never reads the descriptor at
+    // runtime.
+    ProtocolDescriptor() ProtocolDescriptor
+}
+```
+
+### 8.2 PluginLayout
+
+```go
+type PluginLayout interface {
+    // Apply walks `pluginRoot` (the canonical fs.FS view of an
+    // unpacked plugin zip) and writes files into ops at the
+    // agent-specific paths. Returns the list of placed paths so the
+    // workspace record can audit what was written.
+    Apply(ctx context.Context, ops infraops.InfraOps, manifest plugin.Manifest, pluginRoot fs.FS) ([]string, error)
+}
+```
+
+The layout is purely a path-translation policy; it does not read or
+write anything beyond what `pluginRoot` exposes. Implementations live
+next to the agent spec (e.g., `agent/claudecode/layout.go`) so each
+agent type owns its mapping.
+
+### 8.3 ProbeResult
+
+```go
+type ProbeResult struct {
+    Healthy bool
+    // Latency is the round-trip latency of the probe call.
+    Latency time.Duration
+    // Detail is a small, key→value summary surfaced in workspace
+    // status (e.g., "version": "claude-code 1.4.2").
+    Detail map[string]string
+    // Error, when non-nil, explains why Healthy is false.
+    Error *WorkspaceError
+}
+```
+
+### 8.4 ProtocolDescriptor
+
+A stable, JSON-friendly description of how to invoke the workspace.
+The manager treats it as opaque. The shape is:
+
+```go
+type ProtocolDescriptor struct {
+    Kind   ProtocolKind   // "cli" / "rest" / "socket" / future
+    Detail map[string]any // kind-specific
+}
+```
+
+Conventional `Detail` keys per kind are documented in `agent/PLAN.md`
+§ProtocolDescriptor. Examples:
+
+- `kind: "cli"` → `{ "command": ["claude", "code"], "resume_flag": "--resume" }`
+- `kind: "rest"` → `{ "base_url_template": "http://{host}:{port}/v1", "port": 8080 }`
+
+Application assembly code (in the host binary, outside `pkg/manager`)
+maps `ProtocolDescriptor` + the workspace's resolved `InfraOps` to an
+`agentio.Agent`. This bridge is intentionally outside the manager (see
+§11).
+
+### 8.5 InstallParams
+
+```go
+type InstallParams struct {
+    Workspace WorkspaceSummary // namespace, alias, id, plugins (read-only)
+    UserParams map[string]any  // verbatim from CreateWorkspaceRequest.InstallParams
+}
+```
+
+`UserParams` keys are agent-specific and documented per agent's PLAN.
+
+## 9. Logging & Observability
+
+`pkg/manager` follows the repository logging conventions (`AGENTS.md`).
+
+### 9.1 Structured logging
+
+Every log line uses `*slog.Logger` with stable keys:
+
+| Key                | Description |
+|--------------------|-------------|
+| `op`               | Operation name (`manager.create_workspace`, `manager.probe`, …) |
+| `component`        | `"manager"`, `"manager.workspace"`, `"manager.plugin"`, `"manager.probe"` |
+| `workspace_id`     | When the line is workspace-scoped |
+| `workspace_alias`  | Same |
+| `namespace`        | Workspace or plugin namespace |
+| `agent_type`       | `claude-code`, … |
+| `infra_type`       | `localdir`, … |
+| `plugin_id`        | When plugin-scoped |
+| `latency_ms`       | Operation latency |
+| `err`              | Error string (only if `level >= warn`) |
+
+Sensitive values (secrets in `InstallParams`, `InfraOptions`) are
+NEVER logged. Logging the **keys** of those maps is allowed; logging
+**values** is forbidden.
+
+### 9.2 Metrics & traces
+
+v1 emits log-only observability. Metrics endpoints and tracing are not
+in scope. The probe scheduler exposes its inner counters via `Stats()`
+on the scheduler component for tests; production builds attach to it
+through the logger.
+
+### 9.3 Auditing
+
+The manager does not provide a separate audit sink (the orchestrator
+has its own). State transitions in the database (`Workspace.Status`
+moves, `Plugin` create/delete) are the operational record. If
+operators want a separate audit trail, they wrap the repositories.
+
+## 10. Concurrency, Cancellation, Crash Safety
+
+### 10.1 Concurrency model
+
+- The Manager is safe for concurrent use by multiple callers.
+- Plugin CRUD and Workspace CRUD share no locks beyond what the
+  underlying repositories enforce. The default in-memory repositories
+  use one mutex per resource family (one for plugins, one for
+  workspaces).
+- The probe scheduler runs in its own goroutine with a fixed-size
+  worker pool. Workers operate on different workspaces by id; never on
+  the same workspace concurrently.
+- `CreateWorkspace` returns immediately after persisting the `init`
+  row; the install runs in a worker goroutine owned by the manager.
+  Workers are tracked in a `sync.WaitGroup`; `Stop` blocks until all
+  install workers and probe workers terminate.
+
+### 10.2 Cancellation
+
+- Every method takes `context.Context`; ctx cancellation propagates to
+  the underlying `InfraOps` calls (which propagate to subprocess /
+  HTTP calls).
+- Cancelling `CreateWorkspace`'s caller ctx does **not** cancel the
+  install: the install runs under a manager-owned context. To cancel
+  an in-flight install, call `DeleteWorkspace`. The DESIGN deliberately
+  decouples caller lifetime from install lifetime to keep the API
+  ergonomic.
+- `Stop(ctx)` cancels all install / probe contexts and waits for the
+  pool to drain, bounded by the supplied `ctx`. It then calls
+  `Close` on the workspace repository, plugin repository, and plugin
+  storage in that order; close errors are logged but do not abort
+  shutdown. After `Stop`, the Manager rejects new operations with
+  `ErrShutdown`. The manager does NOT close the `*slog.Logger`,
+  `agent.SpecSet`, or `infraops.FactorySet` — those are caller-owned.
+
+### 10.3 Crash safety
+
+- Every observable state transition writes to the repository **before**
+  the side effect that the user cannot reverse:
+  - `init` is persisted before any infra side effect.
+  - `failed` is persisted before any cleanup that destroys evidence.
+  - `healthy` is persisted only after the post-install probe succeeds.
+- Plugin uploads are a two-phase commit:
+  1. The manager resolves the existing `(namespace, name)` row via
+     `PluginRepository.GetByName`; if absent, it allocates a new
+     `PluginID`. Either way, this id is the storage key.
+  2. `PluginStorage.Put(id, body)` writes the blob (overwriting any
+     prior body at the same id atomically per the storage contract).
+  3. `PluginRepository.Insert(plugin)` for fresh rows or
+     `PluginRepository.Update(plugin)` for overwrites; the metadata
+     write is the commit point.
+  If step 3 fails for a fresh upload, the manager calls
+  `PluginStorage.Delete(id)` best-effort, then returns the error.
+  For overwrites, step 3 failure leaves the new blob in place behind
+  the old metadata — a future re-upload re-overwrites; v1 does not
+  reconcile.
+  Orphan blobs (step-3 cleanup also failed) are tolerated — a future
+  GC sweep reconciles. v1 does not ship a GC; operators can run a
+  manual sweep using the `PluginStorage.List` (optional, see
+  `plugin/PLAN.md`).
+
+### 10.4 Manager restart
+
+After a crash or restart:
+
+- Workspaces in `init` may be orphaned (the install worker died). The
+  probe scheduler force-flips `init` workspaces older than
+  `InstallTimeout` to `failed`.
+- Workspaces in `healthy`/`failed` are picked up by the probe loop on
+  the next tick.
+- Plugin orphans (zip with no metadata) are detectable via
+  `PluginStorage.List` minus `PluginRepository.List`; see §10.3.
+
+### 10.5 Loop protection
+
+There is no loop in the manager runtime; every operation is
+finite-step. Probe cadence is bounded by `ProbeInterval`. Install
+attempts are not retried automatically — the operator deletes and
+re-creates if needed.
+
+## 11. Boundary with the Orchestrator
+
+The manager and the orchestrator share **no Go imports**. The
+boundary is enforced at the package level:
+
+- `pkg/manager/...` MUST NOT import `pkg/agentio` or
+  `pkg/orchestrator/...`.
+- `pkg/orchestrator/...` MUST NOT import `pkg/manager/...` (already
+  enforced by orchestrator AGENTS.md).
+
+Integration happens in the **host binary**, outside both packages, by:
+
+1. Reading `Workspace` records from the manager repository (or via
+   `Manager.ListWorkspaces`).
+2. Resolving the workspace's `AgentSpec` (via `Manager.AgentSpec(type)`,
+   to be added if needed; or via the assembly code's own registry).
+3. Calling `agentSpec.ProtocolDescriptor()` to learn the invocation
+   shape.
+4. Using `Manager.NewInfraOps(infraType, infraOptions)` to obtain a
+   live `InfraOps`.
+5. Synthesizing an `agentio.Agent` factory and registering it with
+   `pkg/orchestrator/registry`.
+
+This adapter layer lives in operator code (e.g., `cmd/ana/wiring.go`).
+The manager's role ends at "I can hand you a `ProtocolDescriptor` and
+an `InfraOps`."
+
+> Future change: if multiple binaries need this glue, extract it into
+> a thin package (e.g., `pkg/managerorchestrator`) that imports both
+> `pkg/manager` and `pkg/orchestrator`. The manager itself stays
+> agnostic.
+
+## 12. Module Map
+
+Detailed responsibilities live in each `PLAN.md`. Quick reference:
+
+| Path                                       | Responsibility |
+|--------------------------------------------|----------------|
+| `pkg/manager/manager.go` (root)            | `Manager` interface, `Builder`, top-level types, install worker, probe scheduler wiring |
+| `pkg/manager/types.go` (root)              | Cross-module ID types, request/option shapes, status enum |
+| `pkg/manager/agent/`                       | `AgentSpec` interface + `PluginLayout`, `ProbeResult`, `ProtocolDescriptor`, `InstallParams` |
+| `pkg/manager/agent/claudecode/`            | Reference `AgentSpec` for Claude Code |
+| `pkg/manager/plugin/`                      | `Plugin` data model, `Manifest` schema, on-disk plugin format, `Storage` and `Repository` interfaces, default reference impls |
+| `pkg/manager/infraops/`                    | `InfraOps` interface, `Options`, `Factory`, common types (`ExecCommand`, `ExecResult`) |
+| `pkg/manager/infraops/localdir/`           | Reference `InfraOps` for a local directory |
+| `pkg/manager/workspace/`                   | `Workspace` data model, `Repository` interface (default in-memory impl), status state machine, install worker, probe scheduler |
+
+### 12.1 Dependency graph
+
+```
+                          ┌────────────────────────────────┐
+   Layer 3 (root)         │ pkg/manager (Manager, Builder, │
+                          │ install worker)                │
+                          └────────────┬───────────────────┘
+                                       │ imports all below
+   ┌───────────────────────────────────┴────────────────────┐
+   │                                                        │
+   │  Layer 2:   workspace                                  │
+   │             (→ agent, infraops, plugin)                │
+   │                                                        │
+   │  Layer 1:   agent/claudecode (→ agent, infraops,       │
+   │             plugin)                                    │
+   │             infraops/localdir (→ infraops)             │
+   │                                                        │
+   │  Layer 0:   agent      infraops      plugin            │
+   │             (→ infraops, plugin)  (no internal imports)│
+   │             (no other internal imports)                │
+   │                                                        │
+   └────────────────────────────────────────────────────────┘
+```
+
+Concrete import rules:
+
+- `plugin/` and `infraops/` import nothing from `pkg/manager/...`.
+- `agent/` imports `infraops/` (for `InfraOps` in `Install`/`Probe`)
+  and `plugin/` (for `Manifest` in `PluginLayout`). It MUST NOT
+  import `workspace/` or the root.
+- `agent/claudecode/`, `infraops/localdir/` import only their parent
+  package and the standard library; specifically they MUST NOT depend
+  on `workspace/` or the root.
+- `workspace/` imports `agent/`, `infraops/`, `plugin/`. It MUST NOT
+  import the root package.
+- The root package imports every subpackage to wire the manager.
+- **No transitive import of `pkg/agentio` or `pkg/orchestrator/...`
+  is allowed inside `pkg/manager/...`.** Enforce with a lint check or
+  reviewer discipline.
+
+## 13. v2 Extension Points
+
+The design preserves clean insertion points for the following features.
+None block v1.
+
+- **Plugin versioning.** Add `Plugin.Version` (semver), allow multiple
+  rows per `(namespace, name)`, store one zip per `(id, version)`,
+  add `WorkspaceRepository` migration to track attached versions.
+- **Plugin re-attach / hot upgrade.** New `Manager.UpdateWorkspace`
+  method. Requires AgentSpec to declare `SupportsReinstall()`.
+- **Multi-instance manager.** Replace in-memory repositories with a
+  SQL backend; add a per-row leader election token; the probe
+  scheduler holds a lease.
+- **Authorization / namespacing with ACLs.** Insert a policy hook
+  before `CreatePlugin` and `CreateWorkspace`; manager keeps no
+  identity but accepts `caller` metadata in the request shapes (TBD
+  in v2 design).
+- **Workspace pause / resume.** Add states `paused` and `resuming` to
+  the state machine. Operators stop the daemon without deleting the
+  filesystem state.
+- **Push delivery of status changes.** Adapter consuming a future
+  `StatusEventBus` field on `Builder`; v1 does not emit status
+  events.
+- **Custom probe schedulers.** Allow `Builder.Scheduler` to be set to
+  a user-supplied implementation when the default loop is unsuitable
+  (e.g., distributed deployments).
+
+## 14. Open Questions (deferred)
+
+- **AgentSpec discovery via metadata APIs.** Should `Manager` expose
+  `AgentSpec(type AgentType) (agent.AgentSpec, error)` for assembly
+  code? Today the assembly code carries its own registry alongside
+  the manager. Adding the lookup is convenient but couples consumers
+  to the manager surface. Tentatively yes; finalize during
+  implementation.
+- **Plugin authoring tooling.** Out of scope for the design but
+  influential: a CLI to lint a plugin directory, build the zip, and
+  validate the manifest will materially affect the manifest shape we
+  pin in `plugin/PLAN.md`. v1 ships the format; tooling is separate.
+- **Manager-orchestrator glue.** Whether to extract the integration
+  package now or after observing two consumers. v1 tolerates inline
+  glue.
+- **InfraOps.Stat / Remove / Mkdir.** Pure ergonomic addition; revisit
+  once a second `InfraOps` implementation lands and we know the real
+  duplication cost.
+
+## 15. Glossary
+
+- **Agent** — a *type* of agent program (Claude Code, OpenClaw, …).
+  Represented by `agent.AgentSpec`.
+- **Workspace** — an *instance* of an Agent inside an Infra, persisted
+  in the manager database with a status machine.
+- **Infra** — the runtime environment (local dir, container, sandbox)
+  that hosts a workspace's files and processes.
+- **InfraOps** — the abstract interface the manager uses to act on an
+  infra: `Init`, `Exec`, `PutFile`, `GetFile`, `Request`, `Clear`.
+- **Plugin** — a portable bundle of skills/rules/hooks/subagents in a
+  zip with a manifest, stored in `PluginStorage`.
+- **PluginLayout** — the per-Agent strategy that maps canonical plugin
+  paths to agent-specific paths.
+- **ProtocolDescriptor** — the structured, JSON-friendly description
+  of how to invoke a workspace, returned by `AgentSpec`.
+- **Namespace** — soft partition for alias / plugin-name uniqueness.
+- **Probe** — a non-mutating health check executed by the scheduler.

--- a/pkg/manager/agent/AGENTS.md
+++ b/pkg/manager/agent/AGENTS.md
@@ -1,0 +1,41 @@
+# pkg/manager/agent AGENTS.md
+
+## Scope
+
+Defines the `AgentSpec` interface — the extension point that binds a
+*kind* of agent program (Claude Code, OpenClaw, …) into the manager's
+workspace lifecycle. Owns supporting types (`PluginLayout`,
+`ProbeResult`, `ProtocolDescriptor`, `InstallParams`,
+`WorkspaceSummary`) and the small `SpecSet` registry helper.
+
+Per-agent implementations (e.g., Claude Code) live in subpackages
+(`agent/claudecode/`, …) that import this package.
+
+## Rules
+
+- `AgentSpec` is purely an interface — no default implementation in
+  this package. Concrete specs ship as separate subpackages so each
+  one has a focused review surface.
+- `SpecSet` is concurrency-safe; `Register` returns
+  `ErrAgentTypeConflict` on duplicate `Type()`.
+- All exported types in this package are JSON-serializable wherever a
+  field can flow into the workspace record (`ProtocolDescriptor`,
+  `ProbeResult`). The package documents the field types but does not
+  enforce serialization at compile time.
+- Use the cross-module names from `DESIGN.md` §6.1 / §8 verbatim
+  (`AgentType`, `PluginLayout`, `ProtocolDescriptor`, …); do not invent
+  local synonyms.
+
+## Don'ts
+
+- Do not import `pkg/manager/workspace`, `pkg/manager/plugin`'s
+  storage / repository layer, or the manager root. The dependency
+  graph only allows `agent → infraops` and `agent → plugin` (for
+  `Manifest`); enforce by review.
+- Do not embed transport behavior (HTTP clients, CLI runners) in this
+  package; that is the job of the per-agent subpackage and, at
+  invocation time, the assembly code that translates
+  `ProtocolDescriptor` into an `agentio.Agent`.
+- Do not call `pkg/manager/infraops.InfraOps.Clear`. Only the
+  workspace controller may clear an infra.
+- Do not log spec internals here; this is interface code.

--- a/pkg/manager/agent/PLAN.md
+++ b/pkg/manager/agent/PLAN.md
@@ -1,0 +1,294 @@
+# agent/PLAN.md
+
+## Purpose
+
+Define the **`AgentSpec` interface** — the single extension point that
+binds a kind of agent program (Claude Code, OpenClaw, …) into the
+manager's workspace lifecycle. This package owns:
+
+- The `AgentSpec` interface itself and the supporting types
+  (`PluginLayout`, `ProbeResult`, `ProtocolDescriptor`,
+  `InstallParams`, `WorkspaceSummary`).
+- The narrow registry helper (`SpecSet`) used by the root package to
+  collect and look up registered specs by `Type()`.
+
+It does **not** own concrete implementations. Each implementation
+lives in its own subpackage (`agent/claudecode/`,
+`agent/openclaw/`, …).
+
+## Public surface (intent only)
+
+- `AgentType` — string alias for the spec id, also re-exported from
+  the manager root.
+- `AgentSpec` interface per `DESIGN.md` §8.1.
+- `PluginLayout` interface per `DESIGN.md` §8.2.
+- `ProbeResult` struct per `DESIGN.md` §8.3.
+- `ProtocolDescriptor` struct + `ProtocolKind` enum per
+  `DESIGN.md` §8.4.
+- `InstallParams` struct per `DESIGN.md` §8.5, including the read-only
+  `WorkspaceSummary` view.
+- `SpecSet` helper:
+  - `NewSpecSet() *SpecSet`
+  - `(s *SpecSet) Register(spec AgentSpec) error` — rejects duplicate
+    `Type()`.
+  - `(s *SpecSet) Get(t AgentType) (AgentSpec, bool)`
+  - `(s *SpecSet) Types() []AgentType`
+  - `(s *SpecSet) Len() int`
+- Sentinel errors:
+  - `ErrAgentTypeConflict`
+  - `ErrAgentTypeUnknown`
+  - `ErrInvalidProtocolDescriptor`
+  - `ErrInvalidPluginLayout`
+
+## Behavior rules
+
+### `Type()` is the spec identity
+
+- `Type()` MUST return a non-empty lowercase kebab string,
+  `[a-z][a-z0-9-]{0,31}`. The constructor of the spec validates this.
+- The id is global within a manager and serves as the join key in
+  workspace records (`Workspace.AgentType`).
+
+### `DisplayName()` and `Description()`
+
+- `DisplayName()` returns the human-friendly label shown in operator
+  tooling. Required, non-empty.
+- `Description()` returns up to 1024 characters of markdown-friendly
+  free text. Optional; the empty string is allowed.
+
+### `Install(ctx, ops, params)`
+
+- Caller (the workspace install worker, see `workspace/PLAN.md`) calls
+  `ops.Init` **before** `Install`. Specs MAY assume the working
+  directory exists and is empty.
+- The order of operations within `Install` is implementation-defined,
+  but specs SHOULD:
+  1. Place agent binary / entrypoint (via `ops.PutFile` or
+     `ops.Exec("curl", …)` etc.).
+  2. Write configuration files.
+  3. Optionally start a daemon (HTTP gateway, socket server).
+- Specs MUST be **idempotent under retry within the same call** —
+  i.e., `PutFile`-ing the same target twice MUST NOT fail. They are
+  **not** required to be idempotent across calls; the manager calls
+  `Install` exactly once per workspace.
+- A failure SHOULD return an error wrapped with the phase
+  (`"install: <step>: %w"`). The workspace controller maps the error
+  to a `WorkspaceError{Phase: "install"}` record.
+- `Install` MUST NOT mutate state outside `ops`. Specs that need
+  off-infra side effects (e.g., registering a workspace with a remote
+  service) MUST receive those targets through `params.UserParams` and
+  document the keys.
+
+### `Uninstall(ctx, ops)`
+
+- Best-effort cleanup of anything `Install` started. Stop daemons,
+  release sockets, log out of remote services, etc.
+- The manager calls `ops.Clear` after `Uninstall`, so file-system
+  cleanup is **not** the spec's responsibility.
+- Errors are logged but do NOT block workspace deletion. Specs SHOULD
+  return errors that the operator can act on (e.g., "container kill
+  failed: ...") rather than swallow them.
+- Implementations MUST tolerate the partial-install case: if `Install`
+  failed halfway, `Uninstall` may run against an environment where
+  some state never existed. Treat missing artifacts as success.
+
+### `Probe(ctx, ops)`
+
+- MUST be non-mutating. Side effects break the v2 multi-instance story
+  and confuse operators.
+- SHOULD complete within `ProbeTimeout` (default 5 seconds, set by
+  the manager). Implementations that need longer probes return
+  `Healthy: false` with `ErrTimeout` and the operator tunes
+  `ProbeTimeout` upward.
+- The returned `Detail` map is small (~10 keys, values ≤ 256 chars
+  each). Big payloads belong in operator-supplied logging, not in the
+  workspace record.
+
+### `ProtocolDescriptor()`
+
+- Returns a static, value-typed descriptor. Implementations SHOULD
+  return the same value on every call (the manager treats it as
+  cached). It does not change per-workspace; per-workspace details
+  flow through `InfraOps.Dir()` / `Request(port, ...)` resolution.
+- The descriptor is JSON-serializable: only types `bool`, `string`,
+  `int64`, `float64`, `[]any`, `map[string]any` are allowed in
+  `Detail`. The package validates this lazily; tests SHOULD assert it.
+
+### `PluginLayout()`
+
+- Returns the strategy that knows where in the workspace dir each
+  canonical plugin path goes. Implementations SHOULD be value-typed
+  (no goroutines, no file handles).
+- The strategy MUST handle a plugin manifest with arbitrary subsets
+  of canonical sections (`skills/`, `rules/`, `hooks/`, `subagents/`,
+  `mcps/`, `assets/`); missing sections are not errors.
+
+## Data model
+
+### `AgentType`
+
+```go
+type AgentType string
+```
+
+Validated at registration. Allowed character set:
+`^[a-z][a-z0-9-]{0,31}$`.
+
+### `AgentSpec` (interface, repeating §8.1 for locality)
+
+```go
+type AgentSpec interface {
+    Type() AgentType
+    DisplayName() string
+    Description() string
+    PluginLayout() PluginLayout
+    Install(ctx context.Context, ops infraops.InfraOps, params InstallParams) error
+    Uninstall(ctx context.Context, ops infraops.InfraOps) error
+    Probe(ctx context.Context, ops infraops.InfraOps) (ProbeResult, error)
+    ProtocolDescriptor() ProtocolDescriptor
+}
+```
+
+### `ProtocolDescriptor` and `ProtocolKind`
+
+```go
+type ProtocolKind string
+
+const (
+    ProtocolKindCLI    ProtocolKind = "cli"
+    ProtocolKindREST   ProtocolKind = "rest"
+    ProtocolKindSocket ProtocolKind = "socket"
+)
+
+type ProtocolDescriptor struct {
+    Kind   ProtocolKind
+    Detail map[string]any
+}
+```
+
+Conventional `Detail` keys per kind (NOT enforced here; consumers in
+adapter code rely on these by convention, agents SHOULD NOT invent
+incompatible alternatives without coordinating):
+
+- `cli`:
+  - `command` (`[]string`) — the program + base args, e.g.
+    `["claude", "code"]`.
+  - `cwd_relative_to_dir` (`string`, optional) — subpath under
+    `InfraOps.Dir()` where the CLI must be run; default `""`.
+  - `resume_flag` (`string`, optional) — flag name for session
+    resumption (e.g., `--resume`).
+  - `env` (`[]string`, optional) — extra `KEY=VALUE` pairs.
+- `rest`:
+  - `port` (`int64`) — the port inside the infra; consumed via
+    `InfraOps.Request(port, ...)`.
+  - `base_path` (`string`, optional) — URL path prefix (e.g., `/v1`).
+  - `auth` (`string`, optional) — `"none"` / `"bearer"` /
+    `"basic"`. Token sources are caller-supplied; the manager never
+    stores tokens.
+- `socket`:
+  - `port` (`int64`).
+  - `path` (`string`, optional).
+
+### `InstallParams`
+
+```go
+type InstallParams struct {
+    Workspace  WorkspaceSummary
+    UserParams map[string]any
+}
+
+type WorkspaceSummary struct {
+    ID        WorkspaceID
+    Namespace Namespace
+    Alias     Alias
+    AgentType AgentType
+    InfraType InfraType
+    Plugins   []AttachedPluginRef
+}
+
+type AttachedPluginRef struct {
+    PluginID    PluginID
+    Name        string
+    ContentHash string
+}
+```
+
+`WorkspaceSummary` is read-only; mutating it has no effect because the
+controller writes the row separately. The summary is provided so the
+spec can, for example, name the daemon process after the alias.
+
+### `ProbeResult`
+
+```go
+type ProbeResult struct {
+    Healthy bool
+    Latency time.Duration
+    Detail  map[string]string
+    Error   *WorkspaceError
+}
+```
+
+`WorkspaceError` is the same struct documented in `DESIGN.md` §6.4 and
+re-exported from the root.
+
+## SpecSet
+
+The `SpecSet` helper is owned here so that any package that needs to
+look up specs (the root manager, hypothetical orchestrator-glue
+packages, tests) gets a consistent collection type.
+
+```go
+type SpecSet struct {
+    // unexported map[AgentType]AgentSpec under a sync.RWMutex
+}
+
+func NewSpecSet() *SpecSet
+func (s *SpecSet) Register(spec AgentSpec) error // ErrAgentTypeConflict on duplicate
+func (s *SpecSet) Get(t AgentType) (AgentSpec, bool)
+func (s *SpecSet) Types() []AgentType            // sorted ascending
+func (s *SpecSet) Len() int
+```
+
+The Manager `Builder` uses `SpecSet` internally; consumers may
+construct one directly for tests.
+
+## Edge cases & decisions
+
+- **Two specs with the same Type:** Rejected at `Register`; the second
+  call returns `ErrAgentTypeConflict` and the registry is unchanged.
+- **Spec returns empty Type / DisplayName:** The Manager builder
+  validates these at `Build()` time and refuses to construct.
+- **Missing PluginLayout:** Disallowed. Specs MUST always return a
+  non-nil `PluginLayout`, even if it places no files (see
+  `agent/claudecode/PLAN.md` for what an "empty layout" looks like —
+  it never actually happens in practice but the type makes it
+  expressible).
+- **AgentSpec doing async work in `Install`:** Discouraged. The
+  controller treats `Install` as synchronous. If a spec must launch a
+  daemon, it should do so synchronously (start the process, wait for
+  the readiness signal, return) and rely on `Probe` for liveness
+  checks afterward.
+- **AgentSpec calling `ops.Clear`:** Forbidden. Only the controller
+  calls `Clear`, and only in delete flows. Specs that want to
+  scratch-and-rebuild must re-create files; they MUST NOT clear the
+  directory.
+
+## Tests to write (no implementation in this pass)
+
+1. `SpecSet.Register` rejects duplicate `Type()` with
+   `ErrAgentTypeConflict`.
+2. `SpecSet.Types` returns sorted output.
+3. `ProtocolDescriptor` JSON round-trip preserves `Kind` and a
+   reasonable `Detail` payload.
+4. A fake spec used in tests passes a smoke `Install → Probe →
+   Uninstall` cycle against a fake `infraops.InfraOps`.
+5. Spec with empty `Type()` is rejected at the boundary chosen
+   (registration time, per the rule above).
+
+## Out of scope
+
+- Concrete agent implementations (`claudecode/`, future `openclaw/`,
+  …). They are independent subpackages that import this one.
+- Plugin **manifest** schema definitions; those live in `plugin/`.
+- Any glue with `pkg/agentio` or the orchestrator; per
+  `DESIGN.md` §11, the manager does not import either.

--- a/pkg/manager/agent/claudecode/AGENTS.md
+++ b/pkg/manager/agent/claudecode/AGENTS.md
@@ -1,0 +1,42 @@
+# pkg/manager/agent/claudecode AGENTS.md
+
+## Scope
+
+Reference `agent.AgentSpec` implementation for the **Claude Code** CLI.
+Owns the install routine, plugin layout strategy, probe routine, and
+`ProtocolDescriptor` for Claude Code workspaces. CLI-only — no daemon
+process is started; per-request invocation is the orchestrator CLI
+bridge's responsibility.
+
+This package is one of potentially many concrete agent specs. Other
+agents (OpenClaw, custom HTTP-shaped agents, …) live in sibling
+subpackages.
+
+## Rules
+
+- The `Type()` value is `"claude-code"` and never changes; workspace
+  records depend on this id.
+- Install is idempotent within a single call; the manager calls it
+  exactly once per workspace.
+- Probe is non-mutating. Read-only commands only (`claude --version`).
+- Plugin layout must reject two plugins that sanitize to the same
+  `<name>` segment **before** any `PutFile` call, so the working
+  directory remains coherent on failure.
+- Use `agent.PluginLayout` and `agent.ProtocolDescriptor` types
+  verbatim from the parent package; do not duplicate the type
+  definitions here.
+
+## Don'ts
+
+- Do not embed transport runtime. Per-request invocation belongs to
+  `pkg/bridge/cli`; this spec only describes how to set the workspace
+  up and how to reach it.
+- Do not import `pkg/manager/workspace` or the manager root. The
+  dependency graph allows `agent/claudecode → agent` and
+  `agent/claudecode → infraops` and `agent/claudecode → plugin`,
+  nothing more.
+- Do not log secrets from `InstallParams.UserParams`; treat the map
+  as opaque.
+- Do not download `claude` from the internet inside `Install`.
+  Operator-supplied binaries via PATH or `Options.Binary` only; the
+  manager is not a package manager.

--- a/pkg/manager/agent/claudecode/PLAN.md
+++ b/pkg/manager/agent/claudecode/PLAN.md
@@ -1,0 +1,254 @@
+# agent/claudecode/PLAN.md
+
+## Purpose
+
+Provide the v1 reference `agent.AgentSpec` implementation for the
+**Claude Code** CLI. It pins the conventions for how Claude Code
+workspaces are bootstrapped inside an `infraops.InfraOps`-shaped
+environment, how canonical plugins are projected onto Claude Code's
+expected directory layout, and how operators reach the resulting
+workspace through the orchestrator's CLI bridge.
+
+This is a *reference* implementation: it describes one reasonable way
+to install the binary, manage configuration, and probe liveness for
+Claude Code. Operators who want a different binary path, a different
+config layout, or a custom probe replace the spec.
+
+## Public surface (intent only)
+
+- `Spec` — concrete `agent.AgentSpec` value. Constructed via
+  `New(opts Options) (Spec, error)`.
+- `Options` struct (see §3 below).
+- Sentinel errors local to this package:
+  - `ErrBinaryUnavailable` — `claude --version` returned non-zero or
+    the binary was not found.
+  - `ErrInvalidPluginLayout` — re-exported from `agent` for the
+    layout collision case.
+  All other failures bubble up as wrapped errors (e.g.,
+  `fmt.Errorf("claudecode install put settings: %w", err)`); the
+  workspace controller maps them to `WorkspaceError` records with
+  `Phase: "install"` / `"probe"`.
+- Helper: `LayoutPaths(manifest plugin.Manifest) []string` — exposed
+  for tests; returns the relative paths where the layout would place
+  the plugin's contents.
+
+The `Spec` value is safe to register multiple times across managers
+but only once per manager (per `agent.SpecSet` rules).
+
+## AgentSpec method behavior
+
+### `Type()` and `DisplayName()`
+
+- `Type() == "claude-code"`.
+- `DisplayName() == "Claude Code"`.
+- `Description()` is a 1–3 sentence blurb describing the binary, e.g.
+  "Anthropic's Claude Code CLI as a long-lived workspace bootstrapped
+  in an InfraOps environment."
+
+### `PluginLayout()`
+
+Returns a `claudecode.layout` struct that maps the canonical plugin
+tree onto the per-workspace layout below:
+
+```
+<InfraOps.Dir()>/
+└── .claude/
+    └── plugins/
+        └── <plugin-name>/
+            ├── manifest.toml          # canonical manifest verbatim
+            ├── AGENTS.md              # if present in the plugin
+            ├── skills/                # canonical skills/
+            ├── rules/                 # canonical rules/
+            ├── hooks/                 # canonical hooks/
+            ├── subagents/             # canonical subagents/
+            ├── mcps/                  # canonical mcps/
+            └── assets/                # canonical assets/
+```
+
+Rules:
+
+- The plugin name segment is sanitized: lowercase, `[a-z0-9-]`, max
+  64 chars; conflicts (two plugins with the same sanitized name)
+  return `ErrInvalidPluginLayout` and the workspace install fails.
+- Sections that the plugin does not include are simply not written.
+- Files outside the canonical sections (manifest.toml, AGENTS.md,
+  README.md) are still copied verbatim — they are common author
+  conventions and harmless.
+- The layout MUST NOT modify file contents (no template substitution,
+  no rewriting). The plugin author is responsible for plugin-internal
+  references.
+- If two plugins both want `.claude/plugins/<same-name>/...`, the
+  layout returns `ErrInvalidPluginLayout` before any write — the
+  install worker MUST detect this **before** calling `PutFile`, so
+  the working directory remains coherent.
+
+### `Install(ctx, ops, params)`
+
+Steps in order:
+
+1. **Verify binary.** Run
+   ```go
+   ops.Exec(ctx, infraops.ExecCommand{
+       Program: opts.Binary,            // defaults to "claude"
+       Args:    []string{"--version"},
+   })
+   ```
+   Fail with `ErrBinaryUnavailable` if the exit code is non-zero or
+   the program is not found. The version string is captured for
+   `Probe` to expose.
+2. **Write `.claude/settings.json`.** Minimal seed config:
+   ```json
+   {
+     "schema_version": 1,
+     "workspace": {
+       "alias": "<from params.Workspace.Alias>",
+       "namespace": "<from params.Workspace.Namespace>"
+     }
+   }
+   ```
+   Operators that need richer settings supply them through
+   `Options.SettingsTemplate` (a `text/template`) or post-install
+   tooling.
+3. **Write top-level `AGENTS.md`.** A short, deterministic file that
+   names the workspace and lists attached plugin names. This file is
+   NOT a plugin's AGENTS.md; it is a per-workspace one. Plugins keep
+   their own AGENTS.md inside their plugin directory.
+4. **No daemon.** Claude Code is invoked per-request through the CLI
+   bridge; there is no long-running process to start. `Install`
+   returns success.
+
+`Install` MUST be idempotent within a single call: if step 1 already
+ran successfully and step 2 fails halfway, retrying step 1 is a
+no-op. Cross-call idempotence is not required (the manager calls
+`Install` exactly once per workspace).
+
+### `Uninstall(ctx, ops)`
+
+Returns `nil` immediately. There is no daemon to stop and the
+workspace controller calls `ops.Clear` next, which removes everything
+on disk.
+
+### `Probe(ctx, ops)`
+
+- Runs the same `infraops.ExecCommand` shape as Install step 1
+  (`Program: opts.Binary`, `Args: ["--version"]` by default — or
+  `Options.ProbeArgs` when set).
+- On success: `ProbeResult{Healthy: true, Detail: {"version": ...}}`.
+- On failure: `ProbeResult{Healthy: false, Error: &WorkspaceError{
+  Code: "probe.binary_unavailable", Message: ..., Phase: "probe"}}`.
+- Latency is measured around the `Exec` call and recorded.
+
+Probe duration is dominated by process startup; on a healthy host the
+budget is well under the manager's default `ProbeTimeout` (5s).
+
+### `ProtocolDescriptor()`
+
+```go
+ProtocolDescriptor{
+    Kind: ProtocolKindCLI,
+    Detail: map[string]any{
+        "command":              []any{"claude", "code"},
+        "resume_flag":          "--resume",
+        "cwd_relative_to_dir":  "",
+        "stdin_input":          true,
+    },
+}
+```
+
+The `Detail` keys above are the conventional ones in
+`agent/PLAN.md` §ProtocolDescriptor plus one Claude-Code-specific
+addition (`stdin_input`) signalling that the prompt is delivered
+through stdin (the orchestrator's CLI bridge reads this).
+
+## 3. `Options`
+
+```go
+type Options struct {
+    // Binary, if non-empty, is the absolute path of the Claude Code
+    // executable used by Install / Probe. Defaults to "claude" (relying
+    // on PATH inside the infra).
+    Binary string
+
+    // SettingsTemplate, if non-nil, overrides the default seed
+    // .claude/settings.json. The template receives {Workspace}
+    // (WorkspaceSummary).
+    SettingsTemplate *template.Template
+
+    // ProbeArgs, if non-empty, replaces the default probe command
+    // arguments (`--version`).
+    ProbeArgs []string
+}
+```
+
+`New(opts)` returns `Spec` and validates:
+
+- `Binary`, when set, is non-empty and not a shell metachar string
+  (`;`, `|`, `&`, `>`, `<`).
+- `ProbeArgs` length ≤ 8, no element empty.
+
+## Plugin layout details
+
+The canonical plugin layout (defined in `plugin/PLAN.md`) is mapped
+1:1 with one renaming convention:
+
+| Canonical path           | Workspace path inside `Dir()`                         |
+|--------------------------|-------------------------------------------------------|
+| `manifest.toml`          | `.claude/plugins/<name>/manifest.toml`                |
+| `AGENTS.md`              | `.claude/plugins/<name>/AGENTS.md`                    |
+| `README.md`              | `.claude/plugins/<name>/README.md`                    |
+| `skills/<id>/...`        | `.claude/plugins/<name>/skills/<id>/...`              |
+| `rules/<id>...`          | `.claude/plugins/<name>/rules/<id>...`                |
+| `hooks/<id>...`          | `.claude/plugins/<name>/hooks/<id>...`                |
+| `subagents/<id>...`      | `.claude/plugins/<name>/subagents/<id>...`            |
+| `mcps/<id>...`           | `.claude/plugins/<name>/mcps/<id>...`                 |
+| `assets/<rel>`           | `.claude/plugins/<name>/assets/<rel>`                 |
+
+`<name>` is the **manifest's `name` field** sanitized to
+`[a-z0-9-]{1,64}`. Two plugins with the same sanitized name rejected
+as `ErrInvalidPluginLayout`.
+
+Files at the plugin zip root that are not in the table above are
+copied verbatim to `.claude/plugins/<name>/<basename>` so authors can
+ship freeform extras.
+
+## Edge cases & decisions
+
+- **Operator wants a different plugin root.** Configure the plugin
+  layout via a future `Options.PluginRoot string` knob. v1 hardcodes
+  `.claude/plugins/`; users with strong needs replace the spec
+  entirely.
+- **Plugins claim the same name after sanitization.** Hard error at
+  install; the operator renames one of the plugins. The manager does
+  not auto-disambiguate (collisions usually mean a packaging mistake).
+- **No `claude` binary in the infra.** `Install` fails fast with
+  `ErrBinaryUnavailable`; the workspace ends up in `failed`. Operators
+  fix the infra image and recreate.
+- **Concurrent `Install` for two workspaces sharing a host (localdir
+  with overlapping dirs).** Disallowed by the workspace controller —
+  it reserves the working dir via `InfraOps.Init`. If two specs
+  somehow end up inside the same dir (operator misconfiguration), the
+  later one races and the controller surfaces the resulting error.
+
+## Tests to write (no implementation in this pass)
+
+1. `Type()` is `"claude-code"`.
+2. `Install` happy path against a fake `infraops.InfraOps` writes the
+   expected `.claude/settings.json`, top-level `AGENTS.md`, and the
+   plugin layout for two attached plugins.
+3. `Install` fails with `ErrBinaryUnavailable` when the fake `Exec`
+   returns non-zero.
+4. `PluginLayout.Apply` rejects two plugins that sanitize to the
+   same name.
+5. `Probe` round-trip extracts the version string.
+6. `ProtocolDescriptor()` returns the documented shape and is stable
+   across calls.
+
+## Out of scope
+
+- Bootstrapping the `claude` binary itself (downloading, npm install,
+  permission setting). Operators bake it into the infra image, supply
+  `Options.Binary`, or swap in a custom spec.
+- Custom session-state persistence. Claude Code's own session store
+  lives under the user's home directory; v1 does not relocate it.
+- Multi-process gateways. Claude Code is invoked per-request via the
+  CLI bridge.

--- a/pkg/manager/infraops/AGENTS.md
+++ b/pkg/manager/infraops/AGENTS.md
@@ -1,0 +1,42 @@
+# pkg/manager/infraops AGENTS.md
+
+## Scope
+
+Defines the `InfraOps` interface — the abstraction the manager uses to
+file-and-process its way around a workspace's runtime environment —
+plus the supporting types (`Options`, `ExecCommand`, `ExecResult`,
+`Factory`, `FactorySet`, sentinel errors). Concrete implementations
+live in subpackages (`infraops/localdir/`, future `infraops/docker/`,
+`infraops/e2b/`, …).
+
+## Rules
+
+- The interface surface is intentionally tight (`Init`, `Exec`,
+  `PutFile`, `GetFile`, `Request`, `Clear`, plus `Type` / `Dir`).
+  Adding a method touches every implementation; weigh the cost.
+  Capability extensions (e.g., `Dial`) ship as separate interfaces
+  consumed via type assertion.
+- `Exec` is **structured** — `Program` + `Args`, never a shell line.
+  Implementations that ride a shell quote inputs themselves.
+- `PutFile` / `GetFile` paths are sandboxed inside `Dir()`. Escapes
+  return `ErrPathOutsideDir` before any IO.
+- A non-zero `ExitCode` is data, not an error. `Exec` returns nil
+  error and an `ExecResult` with the code; only operational failures
+  (program missing, ctx cancelled, IO error) populate the error.
+- `Init` is required before any IO method. `Clear` is idempotent and
+  terminal for the instance.
+- Factories MUST be cheap; do work in `Init`.
+
+## Don'ts
+
+- Do not import any other manager subpackage. `infraops` is a leaf.
+- Do not add a method to `InfraOps` without updating every
+  implementation **and** `DESIGN.md` §7.
+- Do not interpret `path` arguments as anything other than relative
+  to `Dir()`. No tilde expansion, no env var substitution, no shell
+  metacharacters.
+- Do not log file or command contents at info level — they may carry
+  secrets. Log structural fields only (`op`, `program`, `path`,
+  `bytes`, `latency_ms`).
+- Do not silently swallow non-zero exit codes. The contract is
+  explicit: callers branch on `ExitCode`.

--- a/pkg/manager/infraops/PLAN.md
+++ b/pkg/manager/infraops/PLAN.md
@@ -1,0 +1,305 @@
+# infraops/PLAN.md
+
+## Purpose
+
+Define the **`InfraOps` interface** — the abstraction over a workspace's
+runtime environment — plus the supporting types (`Options`,
+`ExecCommand`, `ExecResult`, `Factory`, `FactorySet`) and the sentinel
+errors. Concrete implementations (local directory, Docker, E2B, …) live
+in subpackages.
+
+Every interaction with a workspace's filesystem or processes — install
+worker writing files, probe scheduler exec'ing a version check, the
+operator reading a log — flows through `InfraOps`. Picking the right
+abstraction shape is what lets future infras (Docker, E2B, serverless)
+plug in without churn.
+
+## Public surface (intent only)
+
+- Types:
+  - `InfraType` — string alias re-exported from manager root.
+  - `Options` — `map[string]any` value-type alias; JSON-serializable.
+  - `ExecCommand`, `ExecResult` (§3 below).
+  - `InfraOps` interface (`DESIGN.md` §7.1, repeated below).
+  - `Factory` function type — constructs an `InfraOps` from
+    `Options`.
+- `FactorySet` helper:
+  - `NewFactorySet() *FactorySet`
+  - `(s *FactorySet) Register(infraType InfraType, f Factory) error`
+    — duplicate registrations return `ErrInfraTypeConflict`.
+  - `(s *FactorySet) Get(infraType InfraType) (Factory, bool)`
+  - `(s *FactorySet) Types() []InfraType`
+- Sentinels:
+  - `ErrInfraTypeUnknown`
+  - `ErrInfraTypeConflict`
+  - `ErrAlreadyInitialized`
+  - `ErrNotInitialized`
+  - `ErrInvalidOption`
+  - `ErrPathOutsideDir`
+  - `ErrNotARegularFile` (returned by `GetFile` when the path is a
+    directory or special file)
+  - `ErrUnsupportedRequest`
+  - `ErrCleared` (returned by ops on a torn-down infra)
+
+## Interface (verbatim)
+
+```go
+type InfraOps interface {
+    Type() InfraType
+    Dir() string
+
+    Init(ctx context.Context) error
+
+    Exec(ctx context.Context, cmd ExecCommand) (ExecResult, error)
+
+    PutFile(ctx context.Context, path string, content io.Reader, mode fs.FileMode) error
+    GetFile(ctx context.Context, path string) (io.ReadCloser, error)
+
+    Request(ctx context.Context, port int, req *http.Request) (*http.Response, error)
+
+    Clear(ctx context.Context) error
+}
+```
+
+`Type()` returns the same id used to register the factory; the manager
+relies on this for crash-recovery checks ("the persisted type matches
+the implementation we just constructed").
+
+`Dir()` returns the absolute working directory **as it appears inside
+the infra**. For `localdir` this is the host path; for Docker it is
+the container path; for E2B it is the sandbox path. The manager passes
+this to `agent.PluginLayout.Apply` for diagnostics only — file
+operations always go through `PutFile`/`GetFile`.
+
+## ExecCommand & ExecResult
+
+```go
+type ExecCommand struct {
+    Program string            // required; not parsed as a shell line
+    Args    []string          // verbatim; quoting is the implementation's job
+    Env     []string          // KEY=VALUE pairs appended to base env
+    Stdin   io.Reader         // optional
+    WorkDir string            // optional; relative to Dir(); empty = Dir()
+    Stdout  io.Writer         // optional; if set, the implementation streams to it and ExecResult.Stdout is empty
+    Stderr  io.Writer         // optional; same behavior as Stdout
+    Timeout time.Duration     // optional; 0 = use ctx deadline
+}
+
+type ExecResult struct {
+    ExitCode int
+    Stdout   []byte // empty when caller supplied a Stdout writer
+    Stderr   []byte // empty when caller supplied a Stderr writer
+    Duration time.Duration
+}
+```
+
+Behavior rules:
+
+- `Program` MUST be non-empty. The implementation does NOT parse it
+  as a shell command line; that is the caller's responsibility (use
+  `Program: "sh", Args: []string{"-c", "..."}` for shell features).
+- `Env` is appended to the base environment (which is
+  implementation-defined; localdir inherits the manager process env;
+  containerized infras define their own base env).
+- `WorkDir`, when set, is resolved relative to `Dir()`. Absolute paths
+  or paths escaping `Dir()` (resolves outside via `..`) return
+  `ErrPathOutsideDir` before exec.
+- `Timeout`, if positive, overlays a child context with this
+  deadline. The earlier of `ctx.Deadline()` and `Timeout` wins.
+- A non-zero `ExitCode` is **not** an error — `Exec` returns
+  `(ExecResult{ExitCode: N, …}, nil)`. Errors in `Exec` are reserved
+  for operational failures (program not found, IO failure, ctx
+  cancelled). Callers branch on `ExitCode` for application logic.
+- Streaming `Stdout`/`Stderr` and the buffered `[]byte` fields are
+  mutually exclusive per stream: if the caller supplies a writer for
+  one stream, the corresponding result slice is empty (and vice
+  versa).
+
+## File operations
+
+```go
+PutFile(ctx, path, content, mode) error
+GetFile(ctx, path) (io.ReadCloser, error)
+```
+
+Behavior rules:
+
+- `path` is interpreted as relative to `Dir()`. Absolute paths or
+  paths escaping `Dir()` return `ErrPathOutsideDir`.
+- Intermediate directories are created with mode `0755` for
+  `PutFile`. `mode` applies to the resulting file.
+- Existing files at `path` are overwritten atomically (write to a
+  temp sibling then rename). Implementations document deviations
+  per-backend in their PLAN.
+- Symlinks at `path` are followed (the file at the symlink target is
+  replaced). Symlinks **inside** the prefix are otherwise unsupported
+  (most infras forbid them anyway).
+- `GetFile` returns a stream the caller MUST close. The stream may
+  outlive the `InfraOps` for `localdir`; for container backends, the
+  stream MUST keep the connection alive until close.
+
+`PutFile` is the workhorse for plugin layout: an `agent.PluginLayout`
+walks the plugin's `fs.FS` and calls `PutFile` per entry. There is no
+batch upload in v1; backends that benefit from batching wrap the
+interface in their own helper.
+
+## Network operations
+
+```go
+Request(ctx, port, req) (*http.Response, error)
+```
+
+Behavior rules:
+
+- `port` is an inside-the-infra port number. Implementations resolve
+  it to a host:port reachable from the manager process — for
+  `localdir` it is `127.0.0.1:<port>`; for Docker it is the published
+  port (or the bridge IP); for E2B it is the tunneled URL.
+- `req.URL.Host` is overwritten by the resolved address; any value
+  the caller passed is ignored for routing. `req.URL.Scheme` defaults
+  to `http`; HTTPS requires the implementation to expose a separate
+  `Dial` extension (out of v1).
+- The caller supplies a fully-formed `*http.Request` (method, path,
+  body, headers). The implementation passes it through; no header
+  rewriting beyond `Host`.
+- Returns the `*http.Response` from the underlying client. The caller
+  MUST close `resp.Body`.
+- Implementations that cannot expose HTTP at all return
+  `ErrUnsupportedRequest`. The manager treats this as a probe failure.
+
+WebSocket / arbitrary TCP / gRPC are deferred. They will be added as
+extension methods (e.g., `Dial(ctx, port) (net.Conn, error)`) detected
+via type assertion when needed. Adding a method to `InfraOps` itself
+breaks every implementation, so we keep the surface tight.
+
+## Lifecycle
+
+```
+        Factory(opts)
+           │
+           ▼
+   ┌────────────────┐
+   │  constructed   │   Type(), Dir() OK
+   └──────┬─────────┘
+          │ Init()
+   ┌──────▼─────────┐
+   │ initialized    │   all methods OK
+   └──────┬─────────┘
+          │ Clear()
+   ┌──────▼─────────┐
+   │   cleared      │   only Type(), Dir() OK; other ops return ErrCleared
+   └────────────────┘
+```
+
+Rules:
+
+- `Init()` is required before `Exec`/`PutFile`/`GetFile`/`Request`.
+  Calling those before `Init` returns `ErrNotInitialized`.
+- `Init()` is idempotent in the *constructive* sense only: if the
+  backing state already exists from a previous run, `Init` returns
+  `ErrAlreadyInitialized`. The workspace controller catches this on
+  a deliberate-resume path; routine flows treat it as a hard error.
+- `Clear()` is idempotent and safe to call from any post-`Init`
+  state. After `Clear`, the same `InfraOps` instance is dead;
+  callers obtain a fresh instance from the factory if they want to
+  re-init.
+- The same `Options` MAY be passed to `Factory` again after `Clear`;
+  the new instance starts in the constructed state.
+
+### Empty-directory invariant
+
+After `Init` returns nil, `Dir()` exists and contains no files. If
+`Init` finds `Dir()` non-empty, it returns `ErrAlreadyInitialized`
+without touching the contents. The workspace controller relies on
+this for crash safety: if it sees `ErrAlreadyInitialized`, the
+previous attempt already touched the directory and the workspace
+must transition to `failed`.
+
+## Factory
+
+```go
+type Factory func(ctx context.Context, opts Options) (InfraOps, error)
+```
+
+Required option for every factory:
+
+| Key   | Type     | Notes                                |
+|-------|----------|--------------------------------------|
+| `dir` | `string` | Absolute working directory path.     |
+
+Per-implementation options are documented in that implementation's
+PLAN. Examples: `"image"` for Docker, `"template_id"` for E2B,
+`"keep_dir"` for `localdir`.
+
+Factories MUST be cheap: do real work in `Init`, not in the factory.
+The manager constructs `InfraOps` per probe tick.
+
+### FactorySet
+
+```go
+type FactorySet struct {
+    // unexported map[InfraType]Factory under sync.RWMutex
+}
+
+func NewFactorySet() *FactorySet
+func (s *FactorySet) Register(infraType InfraType, f Factory) error
+func (s *FactorySet) Get(infraType InfraType) (Factory, bool)
+func (s *FactorySet) Types() []InfraType
+```
+
+The Manager `Builder` uses `FactorySet` internally; consumers may
+construct one directly for tests.
+
+## Edge cases & decisions
+
+- **Caller passes shell metachars in `Program`.** Allowed; the
+  implementation does no parsing. If the program name itself contains
+  spaces, that is the operator's choice and the implementation honors
+  it.
+- **`PutFile` against a non-existent intermediate directory.**
+  Created with `0755`. To use a different directory mode, write the
+  directory's `.keep` file first with the desired mode (then `Exec`
+  `chmod` if the implementation does not honor the directory mode).
+- **`GetFile` on a directory.** Returns `ErrNotARegularFile` (an
+  exported sentinel in this package). No tar streaming in v1 — call
+  sites that need bulk transfer construct an `ExecCommand` for
+  `tar -cf` and read the resulting archive via a follow-up
+  `GetFile`.
+- **`Request` while the daemon is not yet listening.** Returns the
+  underlying connection error wrapped in
+  `fmt.Errorf("infraops request: %w", err)`. Probes use this to
+  detect liveness.
+- **Two concurrent `PutFile` to the same path.** Last writer wins;
+  atomicity is per-call (temp+rename), so readers always see one
+  consistent file.
+- **Init followed by Clear, then Init again on the same instance.**
+  Disallowed; the cleared instance is dead. Callers create a new
+  one. This keeps state machines simple.
+
+## Tests to write (no implementation in this pass)
+
+1. `FactorySet.Register` rejects duplicates with
+   `ErrInfraTypeConflict`.
+2. A fake `InfraOps` reaches `ErrNotInitialized` for ops invoked
+   before `Init`.
+3. `ExecCommand` validation: empty `Program`, escaping `WorkDir`
+   produce `ErrPathOutsideDir`.
+4. `ExecResult` non-zero `ExitCode` is not an error; an unknown
+   program **is**.
+5. `PutFile` overwrite is atomic — concurrent reader sees either old
+   or new content, never partial.
+6. `Clear` is idempotent.
+7. `Factory` is cheap: a stub factory called 1000× completes within
+   a small budget (regression test against accidental I/O at
+   construct time).
+
+## Out of scope
+
+- Concrete implementations beyond `localdir`. Docker / E2B / serverless
+  are separate subpackages added later.
+- Bulk file transfer (`PutTree` / `GetTree`). Operators use `Exec`
+  with `tar` for now; a future extension may add tree primitives.
+- WebSocket / TCP `Dial`. Extension-interface territory; documented
+  but not implemented in v1.
+- Capability negotiation (e.g., asking the infra "do you support
+  GPU?"). Future via type-assertion-checked extension interfaces.

--- a/pkg/manager/infraops/localdir/AGENTS.md
+++ b/pkg/manager/infraops/localdir/AGENTS.md
@@ -1,0 +1,38 @@
+# pkg/manager/infraops/localdir AGENTS.md
+
+## Scope
+
+Reference `infraops.InfraOps` implementation that targets a local
+directory on the host running the manager. Owns the path-sandbox
+logic (`*os.Root`-based), the `os/exec` wiring for `Exec`, the
+atomic-write `PutFile` implementation, and the loopback HTTP client
+for `Request`. CLI is a leaf in the dependency graph.
+
+## Rules
+
+- Use `*os.Root` (Go 1.24+) to enforce sandboxing on every file
+  operation. Path validation happens **before** any IO so error
+  messages stay precise.
+- Atomic writes via temp+rename + `fsync` are mandatory; partial
+  files would break plugin layout idempotence.
+- Inherit the manager process environment for `Exec` unless the
+  operator opts out via a future `inherit_env: false` option (out of
+  v1).
+- `Clear` always succeeds when the directory is missing. After
+  `Clear` the instance is dead; further calls return
+  `ErrCleared`.
+
+## Don'ts
+
+- Do not import any other manager subpackage. `localdir` only
+  imports `infraops` and the standard library.
+- Do not call `os.Chdir`. The manager process may be running other
+  workspaces concurrently; `Chdir` would leak state.
+- Do not retry `Exec` internally. The manager controls retries (and
+  in v1 does not retry).
+- Do not log file or command **content**. Log structural fields:
+  `op`, `program`, `path`, `bytes`, `latency_ms`, `exit_code`,
+  `err`. Never include stdin/stdout values.
+- Do not silently follow symlinks inserted by an earlier process. If
+  a symlink at `path` resolves outside `Dir()`, treat it as a
+  traversal attempt and return `ErrPathOutsideDir`.

--- a/pkg/manager/infraops/localdir/PLAN.md
+++ b/pkg/manager/infraops/localdir/PLAN.md
@@ -1,0 +1,175 @@
+# infraops/localdir/PLAN.md
+
+## Purpose
+
+Reference `infraops.InfraOps` implementation that targets a **local
+directory on the host running the manager**. It is the simplest infra
+backend and the basis for unit tests, single-machine deployments, and
+the early phases of multi-tenant rollouts before container backends
+land.
+
+## Public surface (intent only)
+
+- `New(opts infraops.Options) (infraops.InfraOps, error)` — registered
+  with the manager via
+  `Builder.RegisterInfraType("localdir", localdir.New)`.
+- `Type() == "localdir"` for any constructed instance.
+- Sentinels:
+  - `ErrInvalidDir` (wrapping `infraops.ErrInvalidOption`)
+  - `ErrDirNotEmpty`
+- No long-lived resources beyond the absolute path; instances are
+  cheap value-types backed by an `*os.Root` (Go 1.24+) for safe path
+  resolution.
+
+## Options
+
+```go
+infraops.Options{
+    "dir":      "/var/lib/ana/workspaces/<alias>",  // REQUIRED, absolute
+    "keep_dir": true,                               // OPTIONAL, default false
+    "umask":    0o022,                              // OPTIONAL, default 0o022
+    "base_env": []string{"LANG=C.UTF-8"},           // OPTIONAL; appended to inherited env
+    "request_loopback_host": "127.0.0.1",           // OPTIONAL; default 127.0.0.1
+}
+```
+
+Validation:
+
+- `dir` MUST be a non-empty absolute path. The factory returns
+  `ErrInvalidDir` otherwise.
+- `dir` MUST resolve outside reserved system locations (`/`, `/etc`,
+  `/usr`, `/bin`, `/sbin`, `/var/log`, `$HOME`-relative parents). The
+  v1 reference checks against a hard-coded deny list with `slog.Warn`
+  on overlap; operators that need other paths replace the validator
+  via a future `Options["allow_path"]` knob (out of v1).
+- `keep_dir`, when `true`, instructs `Clear` to remove the directory's
+  contents but leave the directory itself in place (useful when an
+  enclosing volume is mounted by the operator). Default `false`:
+  remove the whole directory.
+- `umask` is applied around `PutFile` writes via `os.OpenFile` mode
+  bits. Default `0o022`.
+- `base_env` is the literal slice prepended to the manager process'
+  env (which is otherwise inherited verbatim by `Exec`).
+- `request_loopback_host` overrides the IP/host used by `Request`
+  (default `127.0.0.1`). IPv6 callers set `"::1"`.
+
+Unknown keys produce `ErrInvalidOption` so typos do not silently
+drift; the v1 reference uses an allow-list of the keys above.
+
+## Lifecycle implementation notes
+
+### `Init(ctx)`
+
+1. Stat the parent of `dir`; if missing, return
+   `ErrInvalidDir`.
+2. Stat `dir`. If it exists and is non-empty, return
+   `ErrAlreadyInitialized` (per the interface contract).
+3. If it exists and is empty, accept it. Otherwise, `os.MkdirAll(dir,
+   0o755)`.
+4. Open an `*os.Root` rooted at `dir` and stash it on the instance —
+   subsequent file ops resolve through it, blocking traversal
+   escapes natively.
+
+### `Exec(ctx, cmd)`
+
+1. Validate `cmd.Program` (non-empty), `cmd.WorkDir` (relative,
+   resolves inside `Dir()`).
+2. Build `*exec.CommandContext` with derived ctx (for the optional
+   `Timeout`).
+3. Inherit the manager process env, append `base_env`, append
+   `cmd.Env`.
+4. Wire `Stdin` if provided; wire `Stdout`/`Stderr` to either the
+   caller's writer or a `bytes.Buffer` capped at 8 MiB per stream
+   (oversized output emits a `slog.Warn` and truncates).
+5. `Run` and translate `*exec.ExitError` → `ExitCode` field. Other
+   errors (program not found, IO failure) bubble up.
+6. Record `Duration`.
+
+### `PutFile(ctx, path, content, mode)`
+
+1. Resolve `path` through the `*os.Root`; reject escapes.
+2. `MkdirAll` the parent (via `Root.MkdirAll`) with `0o755 & ^umask`.
+3. Write to a tempfile sibling (`.<basename>.tmp.<rand>`) with the
+   requested `mode` masked by `umask`.
+4. `fsync` the file, `rename` over the destination.
+5. `fsync` the parent directory.
+6. Honor ctx cancellation: cancel the ongoing copy by switching to a
+   ctx-aware reader wrapper.
+
+### `GetFile(ctx, path)`
+
+1. Resolve through `*os.Root`.
+2. `os.Open`; the caller closes.
+3. Return a thin wrapper that aborts further reads on ctx cancel
+   (since `os.File` does not honor ctx natively, the wrapper checks
+   `ctx.Err()` per chunk; chunk size 64 KiB).
+
+### `Request(ctx, port, req)`
+
+1. Override `req.URL.Scheme = "http"`, `req.URL.Host =
+   net.JoinHostPort(loopback, strconv.Itoa(port))`.
+2. Use a `*http.Client` per instance with a 30s default transport
+   timeout (caller's ctx still wins).
+3. Pass-through; close the response body is the caller's job.
+
+The HTTP client is reused across calls; per-instance not per-call to
+avoid socket churn.
+
+### `Clear(ctx)`
+
+1. If `keep_dir == true`: walk `Dir()` and delete entries while
+   leaving `Dir()` itself.
+2. Otherwise: `os.RemoveAll(Dir())`.
+3. Mark the instance as cleared; subsequent ops return
+   `ErrCleared`.
+
+`Clear` is idempotent; deleting a missing directory returns nil.
+
+## Concurrency
+
+- Multiple goroutines may call any method on the same instance
+  concurrently. The instance protects internal state (e.g., the
+  cleared flag, the HTTP client) with a mutex; the underlying file
+  system handles per-call atomicity.
+- Two `localdir` instances pointing at the same `dir` would race;
+  the manager refuses to register two workspaces with the same
+  `localdir.dir`. (This check happens at workspace-creation time,
+  not in this package.)
+
+## Safety
+
+- `*os.Root` (Go 1.24+) prevents traversal escapes natively. Earlier
+  Go fallback uses a `filepath.Clean` + prefix check; the package
+  builds with `go1.24` or newer.
+- Symlinks **inside** `Dir()` are followed for reads (consistent
+  with normal POSIX behavior); they are **not** created by `PutFile`.
+- The factory rejects `dir` paths whose parent does not already
+  exist, to avoid surprise `MkdirAll` of `/tmp/some/deep/path`.
+
+## Tests to write (no implementation in this pass)
+
+1. `New` rejects relative `dir`, missing `dir`, deny-listed roots,
+   unknown options.
+2. `Init` happy path: empty dir → no-op; missing dir → created.
+3. `Init` on a non-empty dir returns `ErrAlreadyInitialized` and
+   does not modify contents.
+4. `Exec` honors `WorkDir` relative to `Dir()`; rejects escapes.
+5. `Exec` non-zero exit produces nil error + correct `ExitCode`.
+6. `Exec` ctx cancel kills the child process within ~250 ms.
+7. `PutFile` is atomic — concurrent reader sees old or new content,
+   never partial.
+8. `PutFile` rejects path escapes via `*os.Root`.
+9. `GetFile` aborts on ctx cancel.
+10. `Request` default host is `127.0.0.1`; override works.
+11. `Clear` with `keep_dir` true vs false.
+12. Cleared instance returns `ErrCleared` for ops; another `New(opts)`
+    yields a fresh instance.
+13. `-race` over a mixed read/write workload.
+
+## Out of scope
+
+- Containers, sandboxes, remote SSH. Those are sibling packages.
+- Resource limits (CPU / memory / disk). The host's facilities
+  (cgroups, ulimit) apply outside the manager's purview.
+- Snapshotting. `Clear` followed by `New + Init` reproduces the
+  empty-dir state; backup/restore is operator territory.

--- a/pkg/manager/plugin/AGENTS.md
+++ b/pkg/manager/plugin/AGENTS.md
@@ -1,0 +1,46 @@
+# pkg/manager/plugin AGENTS.md
+
+## Scope
+
+Plugin data layer: the on-disk plugin package format (zip layout +
+`manifest.toml`), the `Plugin` value type, the `Manifest` schema, the
+`Repository` interface (metadata persistence) and the `Storage`
+interface (blob persistence), plus reference in-memory implementations
+(`MemoryRepository`, `MemoryStorage`) used in tests.
+
+This package is agent-agnostic and transport-agnostic. Per-agent
+layout policies live in `pkg/manager/agent/<type>/`; production
+storage backends (S3, GCS, …) live in operator code.
+
+## Rules
+
+- The plugin package format is the contract with plugin authors. Any
+  change to the manifest schema or zip layout requires a
+  `schema_version` bump and an entry in `DESIGN.md`.
+- All exported helpers (`ParseManifest`, `ValidateManifest`,
+  `OpenZipReader`, `OpenZipReaderFromStream`, `Hash`) are pure
+  functions — no IO that the caller cannot observe through the
+  supplied reader. `OpenZipReaderFromStream` may allocate a buffer
+  bounded by `maxSize`; that is its only side effect.
+- `Repository.Insert` and `Repository.Update` are atomic with respect
+  to themselves and each other. Verify with `go test -race`.
+- `Storage.Put` overwrite is atomic from a `Get`-er's perspective.
+  Verify with `go test -race`.
+- `MemoryStorage.PresignURL` returns `ErrUnsupported`; durable
+  backends implement it.
+
+## Don'ts
+
+- Do not import `pkg/manager/agent`, `pkg/manager/workspace`, or the
+  manager root. Plugin is a leaf module in the dependency graph.
+- Do not couple to a specific transport (HTTP handlers, gRPC, S3 SDK).
+  Backends plug in through the `Storage` interface.
+- Do not perform plugin **content** transformations here (renaming
+  files, rewriting manifests). Layout decisions belong to
+  `agent.PluginLayout` implementations.
+- Do not silently downgrade a `schema_version` mismatch. Reject with
+  `ErrInvalidManifest`; the operator updates the plugin or pins an
+  older manager.
+- Do not log plugin metadata values that may carry author secrets
+  (license keys, credentials). The `metadata` table is free-form;
+  treat it as opaque.

--- a/pkg/manager/plugin/PLAN.md
+++ b/pkg/manager/plugin/PLAN.md
@@ -1,0 +1,376 @@
+# plugin/PLAN.md
+
+## Purpose
+
+Own everything plugin-related at the data layer:
+
+- The on-disk **plugin package format** (zip layout + `manifest.toml`).
+- The `Plugin` value type and the `Manifest` schema.
+- The `Repository` interface (metadata persistence).
+- The `Storage` interface (blob persistence) and a `MemoryStorage`
+  reference implementation for tests.
+- A `MemoryRepository` reference implementation for tests.
+- Helpers for parsing and validating manifests, and for streaming a
+  zip body into a virtual file system that callers (specifically
+  `agent.PluginLayout` implementations) consume to lay files out
+  inside an `InfraOps`.
+
+This package is **agnostic** to:
+
+- the agent kind (no Claude Code awareness),
+- the transport (no HTTP, no S3 — `Storage` is the abstraction),
+- the workspace (no `WorkspaceID` references).
+
+## Public surface (intent only)
+
+- Types:
+  - `Plugin` per `DESIGN.md` §6.2.
+  - `Manifest` per §3 below.
+  - `Section` enum for the canonical sections.
+- `Repository` interface (§4).
+- `Storage` interface (§5).
+- `Reader` interface — fs.FS-shaped view over an unpacked plugin
+  package, used by `agent.PluginLayout.Apply`. Covered in §6.
+- Helpers:
+  - `ParseManifest(data []byte) (Manifest, error)`
+  - `ValidateManifest(m Manifest) error`
+  - `OpenZipReader(r io.ReaderAt, size int64) (Reader, error)` —
+    when the caller already has a `ReaderAt` (e.g., file-backed
+    storage) and the exact size.
+  - `OpenZipReaderFromStream(ctx context.Context, r io.Reader, sizeHint int64, maxSize int64) (Reader, error)` —
+    convenience wrapper that buffers the stream into memory (or an
+    operator-supplied tempfile via a future option) up to `maxSize`
+    bytes and then calls `OpenZipReader`. `sizeHint` lets the
+    implementation pre-size the buffer when known. Used by the
+    workspace install worker, which receives an `io.ReadCloser`
+    from `Storage.Get`.
+  - `Hash(content io.Reader) (sha string, n int64, err error)`
+- Sentinels:
+  - `ErrPluginNotFound`
+  - `ErrPluginNameConflict`
+  - `ErrInvalidManifest`
+  - `ErrCorruptArchive`
+  - `ErrStorageClosed`
+  - `ErrStorageNotFound`
+  - `ErrUnsupported` — returned by `Storage` methods that a backend
+    cannot implement (e.g., `MemoryStorage.PresignURL`).
+  - `ErrUnsupportedDownloadURL` — manager-level wrapper of
+    `ErrUnsupported` returned from `Manager.GetPluginDownloadURL`
+    when the configured backend does not mint URLs.
+
+## Plugin package format
+
+A plugin is a zip file that has the following layout. Section names
+are reserved; everything else at the root is preserved verbatim and
+made available to per-agent layouts that want it.
+
+```
+plugin.zip
+├── manifest.toml          # REQUIRED. See §3.
+├── README.md              # OPTIONAL. Author-facing overview.
+├── AGENTS.md              # OPTIONAL. Agent-facing context, copied per layout rules.
+├── skills/                # OPTIONAL. One subdirectory per skill (e.g., skills/<id>/SKILL.md + extras).
+├── rules/                 # OPTIONAL. Files (e.g., *.mdc, *.md) describing rules.
+├── hooks/                 # OPTIONAL. Hook descriptors (e.g., hooks.json + scripts).
+├── subagents/             # OPTIONAL. Subagent prompt + config files.
+├── mcps/                  # OPTIONAL. MCP server descriptors.
+└── assets/                # OPTIONAL. Free-form referenced files.
+```
+
+Reserved names at zip root: `manifest.toml`, `README.md`, `AGENTS.md`,
+`skills/`, `rules/`, `hooks/`, `subagents/`, `mcps/`, `assets/`. All
+other names at the root are passed through but emit a `slog` warning
+during ingest.
+
+### File-level rules
+
+- All paths inside the zip use forward slashes and are relative to
+  the zip root. Absolute paths or paths containing `..` are rejected
+  as `ErrCorruptArchive`.
+- File modes are stored verbatim; on extraction the layout decides
+  whether to honor or normalize them (default: `0644` for files,
+  `0755` for directories, executable bit kept if the source set it).
+- Default maximum **compressed** body size: 64 MiB. Enforced by
+  `Manager.CreatePlugin` before calling `Storage.Put`; the storage
+  and repository layers trust the input. Operators that need larger
+  plugins raise the limit at the manager root.
+- Default maximum **decompressed** size during extraction: 256 MiB.
+  Enforced by `OpenZipReaderFromStream` when it expands entries.
+  Plugins beyond this are rejected as `ErrCorruptArchive` (a hostile
+  zip-bomb defense, not a feature limit).
+- Symlinks are rejected. Plugins MUST be portable across infras.
+
+## Manifest
+
+The manifest is `manifest.toml` at the zip root.
+
+```toml
+schema_version = 1
+
+[plugin]
+name        = "trading-research"
+description = "Stock-research skills + hooks for Alice."
+
+[plugin.metadata]
+author        = "ANA contributors"
+license       = "MIT"
+homepage      = "https://example.invalid/trading-research"
+tags          = ["finance", "research"]
+
+# All four sections below are optional. Each section is a table whose
+# entries describe one resource. The keys MAY restate the on-disk path
+# (`path = "skills/<id>"`) but they MUST match what the zip actually
+# contains; mismatches cause ErrInvalidManifest.
+
+[skills.stock_lookup]
+display_name = "Stock lookup"
+path         = "skills/stock_lookup"
+
+[skills.macro_recap]
+display_name = "Macro recap"
+path         = "skills/macro_recap"
+
+[rules.style]
+description = "Tone and citation rules"
+path        = "rules/style.mdc"
+
+[hooks.on_request]
+description = "Pre-request normalizer"
+path        = "hooks/on_request.json"
+
+[subagents.researcher]
+description = "Researcher subagent"
+path        = "subagents/researcher.md"
+
+[mcps.web]
+description = "Web search MCP"
+path        = "mcps/web.json"
+```
+
+### Validation rules
+
+- `schema_version` MUST equal `1`. Future schemas bump the number; the
+  package documents migrations.
+- `plugin.name` matches `[a-z0-9-]{1,64}`. It is the canonical
+  identity used in directory placement.
+- `plugin.description` ≤ 1024 characters; markdown-friendly free text.
+- `plugin.metadata` is a free table; the package validates only that
+  it is a TOML table (no nested arrays beyond simple scalar arrays
+  like `tags`).
+- Each section entry MUST point to a `path` that exists in the zip.
+  Validation walks the archive once and produces all mismatches in a
+  single error.
+- Duplicated entry keys across sections are allowed (e.g., `skills.x`
+  and `rules.x`). Within one section, keys are unique.
+
+`ParseManifest` returns the structured value; `ValidateManifest`
+runs the rules above plus cross-validates against the archive when
+called via `OpenZipReader` (which threads the validation internally).
+
+### Manifest Go shape
+
+```go
+type Manifest struct {
+    SchemaVersion int                            `toml:"schema_version"`
+    Plugin        ManifestPlugin                 `toml:"plugin"`
+    Skills        map[string]ManifestEntry       `toml:"skills,omitempty"`
+    Rules         map[string]ManifestEntry       `toml:"rules,omitempty"`
+    Hooks         map[string]ManifestEntry       `toml:"hooks,omitempty"`
+    Subagents     map[string]ManifestEntry       `toml:"subagents,omitempty"`
+    MCPs          map[string]ManifestEntry       `toml:"mcps,omitempty"`
+}
+
+type ManifestPlugin struct {
+    Name        string                 `toml:"name"`
+    Description string                 `toml:"description,omitempty"`
+    Metadata    map[string]any         `toml:"metadata,omitempty"`
+}
+
+type ManifestEntry struct {
+    Description string `toml:"description,omitempty"`
+    DisplayName string `toml:"display_name,omitempty"`
+    Path        string `toml:"path"`
+}
+```
+
+The `Plugin.Manifest` field on the manager `Plugin` value (per
+`DESIGN.md` §6.2) is `Manifest` — copied by value at upload time.
+
+## Repository
+
+```go
+type Repository interface {
+    // Insert atomically inserts a Plugin row. Returns
+    // ErrPluginNameConflict when (Namespace, Name) is taken.
+    Insert(ctx context.Context, p Plugin) error
+
+    // Update replaces an existing Plugin (used for "overwrite on
+    // re-upload"). Implementations MUST keep the original ID and
+    // CreatedAt; the input's UpdatedAt is taken verbatim.
+    Update(ctx context.Context, p Plugin) error
+
+    Get(ctx context.Context, id PluginID) (Plugin, error)
+    GetByName(ctx context.Context, namespace Namespace, name string) (Plugin, error)
+    List(ctx context.Context, opts ListOptions) ([]Plugin, string, error) // returns (rows, nextCursor, err)
+    Delete(ctx context.Context, id PluginID) error
+    Close(ctx context.Context) error
+}
+
+type ListOptions struct {
+    Namespace Namespace
+    NameLike  string
+    Limit     int
+    Cursor    string
+}
+```
+
+Implementations:
+
+- `MemoryRepository` — reference, mutex-protected, suitable for
+  tests.
+- Production deployments supply a SQL-backed implementation and
+  inject it through `Builder.PluginRepository`. v1 ships only the
+  in-memory reference.
+
+### Concurrency contract
+
+- All methods are safe for concurrent use.
+- `Insert` and `Update` MUST be atomic with respect to themselves and
+  each other. The combined "upsert" used by `Manager.CreatePlugin`
+  is implemented as `Insert` then, on `ErrPluginNameConflict`,
+  `Update`. Implementations MAY expose a private `Upsert` for
+  efficiency but it is not part of the v1 surface.
+
+## Storage
+
+```go
+type Storage interface {
+    // Put stores the zip body under `id`. Implementations MUST detect
+    // that the same `id` is being written concurrently and either
+    // serialize or fail with ErrStorageBusy (an internal sentinel
+    // that callers retry; not exported in v1).
+    Put(ctx context.Context, id PluginID, body io.Reader) (StoredObject, error)
+
+    // Get returns a streaming reader for the stored body.
+    Get(ctx context.Context, id PluginID) (io.ReadCloser, StoredObject, error)
+
+    // Delete is idempotent; deleting a missing id returns nil.
+    Delete(ctx context.Context, id PluginID) error
+
+    // PresignURL returns a time-limited URL the caller can use to
+    // download the body without going through the manager. The
+    // implementation may return ErrUnsupported when the backend
+    // cannot mint URLs (e.g., MemoryStorage); the manager surfaces
+    // that as ErrUnsupportedDownloadURL and the caller falls back
+    // to streaming Get.
+    PresignURL(ctx context.Context, id PluginID, opts PresignOptions) (string, error)
+
+    // Optional housekeeping; implementations may return ErrUnsupported.
+    List(ctx context.Context) ([]PluginID, error)
+
+    Close(ctx context.Context) error
+}
+
+type StoredObject struct {
+    Size        int64
+    ContentHash string // sha256:<hex>; computed by manager and verified on retrieval
+}
+
+type PresignOptions struct {
+    TTL     time.Duration
+    Method  string // "GET" by default; future: "PUT" for uploads (out of v1)
+}
+```
+
+Implementations:
+
+- `MemoryStorage` — keeps zip bodies in a `map[PluginID][]byte` under
+  a mutex. Returns `ErrUnsupported` from `PresignURL` and
+  `ErrUnsupported` from `List` is allowed but the reference
+  implementation supports `List` for tests.
+- Production deployments supply an S3- or GCS-backed implementation
+  and inject it through `Builder.PluginStorage`.
+
+### Concurrency contract
+
+- All methods are safe for concurrent use.
+- `Put` MUST overwrite a previous body for the same id atomically: a
+  concurrent `Get` either sees the old body or the new body, never a
+  mix. `MemoryStorage` achieves this with a write-lock around the
+  swap; backends that lack this guarantee MUST keep both versions
+  briefly and switch references atomically.
+
+## Reader (unpacked plugin)
+
+```go
+type Reader interface {
+    // Manifest returns the parsed manifest for the plugin.
+    Manifest() Manifest
+    // FS returns an fs.FS rooted at the zip root, with directories
+    // mirroring the on-disk layout. Implementations MUST NOT decode
+    // entries lazily in a way that races with Close.
+    FS() fs.FS
+    // Close releases any underlying resources (e.g., the zip reader).
+    Close() error
+}
+```
+
+`OpenZipReader(r io.ReaderAt, size int64) (Reader, error)` validates
+the manifest against the archive contents and returns the reader.
+
+`agent.PluginLayout.Apply` consumes a `Reader.FS()` to walk the tree
+and stream files into `InfraOps.PutFile`. The `Reader` is short-lived
+— closed after layout finishes.
+
+## Edge cases & decisions
+
+- **Zip without manifest.** Rejected as `ErrInvalidManifest` at
+  `OpenZipReader`.
+- **Manifest references a missing path.** Rejected with a single
+  `ErrInvalidManifest` carrying every miss as `errors.Join`.
+- **Re-upload (same `(namespace, name)`).** `Manager.CreatePlugin`
+  treats this as overwrite. The flow is:
+  1. `Repository.GetByName(ns, name)` resolves the existing
+     `PluginID` (if any).
+  2. `Storage.Put(existingID, body)` overwrites the previous zip
+     under the **same** id (per the Storage atomicity contract above).
+  3. `Repository.Update(plugin)` rewrites the metadata row, keeping
+     `ID` and `CreatedAt` unchanged and bumping `UpdatedAt`,
+     `ContentHash`, `Size`, and `Manifest`.
+  Workspaces that attached the plugin previously are not affected;
+  they own their extracted files. There is no "freshly-keyed" blob —
+  the blob lives under the original id for the lifetime of the
+  Plugin row.
+- **Storage out of disk.** `Put` returns the underlying error wrapped
+  as `fmt.Errorf("plugin storage put: %w", err)`. The manager fails
+  the upload and does not retry.
+- **Storage and Repository drift (orphan blob).** Tolerated; surfaced
+  via the optional `Storage.List` minus `Repository.List`. v1 does
+  not ship a sweep loop.
+- **Aggregate size limits.** Enforced by manager-level options before
+  calling `Storage.Put`; the storage layer itself trusts the input.
+
+## Tests to write (no implementation in this pass)
+
+1. `MemoryRepository` round-trip (`Insert`, `Get`, `GetByName`,
+   `List`, `Delete`).
+2. `MemoryStorage` Put/Get/Delete with hash verification.
+3. `MemoryStorage.Put` overwrite atomicity under `-race`.
+4. `ParseManifest` accepts the example in §3, rejects empty `name`,
+   wrong `schema_version`, missing path, etc.
+5. `OpenZipReader` rejects archives with absolute paths, `..`, or
+   symlinks.
+6. `Reader.FS()` round-trip over a synthetic zip.
+7. `OpenZipReaderFromStream` honors `maxSize` and rejects oversized
+   archives with `ErrCorruptArchive`.
+8. `Repository.Insert` rejects duplicates with
+   `ErrPluginNameConflict`.
+
+## Out of scope
+
+- Concrete production storage backends (S3, GCS, local-fs).
+  Operators implement them and inject through the Builder.
+- A plugin-authoring CLI (lint/build/sign). It will live in a
+  separate package once the format stabilizes.
+- Cross-plugin dependencies (one plugin requiring another). v2.
+- Signing / verification. v2.

--- a/pkg/manager/workspace/AGENTS.md
+++ b/pkg/manager/workspace/AGENTS.md
@@ -1,0 +1,53 @@
+# pkg/manager/workspace AGENTS.md
+
+## Scope
+
+Workspace lifecycle engine: the `Workspace` data model, the
+`Repository` interface (and a `MemoryRepository` reference impl), the
+status state machine, the `Controller` that drives `CreateWorkspace`
+and `DeleteWorkspace` end-to-end, and the `ProbeScheduler` that
+periodically probes active workspaces.
+
+This package is the only writer of `Workspace.Status`. The state
+machine in `DESIGN.md` §5.1 is the source of truth.
+
+## Rules
+
+- The `Controller` is the **only** writer of the `init → {healthy,
+  failed}` transition. The `ProbeScheduler` is the **only** writer
+  of `{healthy ↔ failed}` and the `init → failed` install-timeout
+  watchdog. Repository implementations enforce this with
+  `UpdateStatus`-only transitions and reject status mutations from
+  the generic `Update` method.
+- Persist before side effects: `init` is written before any infra
+  call; terminal status is written after the side effects complete.
+  This invariant lets the manager recover after restart.
+- `Controller.Submit` returns immediately after queuing; the install
+  runs on a worker. `Controller.Delete` is synchronous.
+- `ProbeScheduler` skips `init` rows except for the install-timeout
+  watchdog. Probes are non-mutating by spec; never trigger an
+  install retry from within a probe.
+- Use the cross-module names from `DESIGN.md` §6 verbatim
+  (`Status`, `WorkspaceID`, `Namespace`, `Alias`, …).
+- Run `go test -race` for any change in this package — the
+  controller, scheduler, and repository all coordinate under
+  contention.
+
+## Don'ts
+
+- Do not perform retries with policy here. The v1 controller writes
+  `failed` and lets the operator decide. Retry/back-off lives in v2
+  with explicit knobs.
+- Do not start goroutines outside the documented pools (install
+  workers, scheduler workers). New goroutines need a Builder option
+  and a deterministic shutdown path.
+- Do not import the manager root package or `pkg/agentio`. The
+  dependency graph allows `workspace → {agent, infraops, plugin}`,
+  nothing more.
+- Do not log secrets from `InstallParams` or `InfraOptions`. Log
+  structural fields only (`workspace_id`, `workspace_alias`,
+  `namespace`, `agent_type`, `infra_type`, `phase`,
+  `latency_ms`, `err`).
+- Do not delete plugin storage records from this package. The
+  workspace controller copies plugin contents at install time and
+  never reaches back into `plugin.Storage` afterwards.

--- a/pkg/manager/workspace/PLAN.md
+++ b/pkg/manager/workspace/PLAN.md
@@ -1,0 +1,338 @@
+# workspace/PLAN.md
+
+## Purpose
+
+Own the workspace **lifecycle engine**:
+
+- The `Workspace` data model (per `DESIGN.md` §6.3) and the
+  `Repository` interface that persists it.
+- The `Status` state machine and the validated transitions.
+- The `Controller` that drives `CreateWorkspace` / `DeleteWorkspace`
+  end-to-end (calling into `agent.AgentSpec` and `infraops.InfraOps`
+  per `DESIGN.md` §4).
+- The `ProbeScheduler` that periodically calls `AgentSpec.Probe` on
+  active workspaces and updates status.
+
+This package depends on `agent/`, `infraops/`, and `plugin/`. It is
+imported by the manager root package and nothing else.
+
+## Public surface (intent only)
+
+- Types (the manager root re-exports these with `Workspace`-prefixed
+  names per `DESIGN.md` §6 — `WorkspaceStatus`, `WorkspaceError`):
+  - `Workspace` value type per `DESIGN.md` §6.3.
+  - `Status` enum: `init`, `healthy`, `failed`.
+  - `Error` — diagnostic record per `DESIGN.md` §6.4.
+  - `AttachedPlugin` per `DESIGN.md` §6.5.
+- `Repository` interface (§3 below).
+- `Controller` struct + `ControllerConfig` (§4).
+- `ProbeScheduler` struct + `ProbeSchedulerConfig` (§5).
+- Sentinel errors:
+  - `ErrWorkspaceNotFound`
+  - `ErrAliasConflict`
+  - `ErrInvalidStatusTransition`
+  - `ErrInstallTimeout`
+  - `ErrControllerShutdown`
+  - `ErrSchedulerShutdown`
+
+## Repository
+
+```go
+type Repository interface {
+    Insert(ctx context.Context, w Workspace) error
+    Get(ctx context.Context, id WorkspaceID) (Workspace, error)
+    GetByAlias(ctx context.Context, namespace Namespace, alias Alias) (Workspace, error)
+    List(ctx context.Context, opts ListOptions) ([]Workspace, string, error) // rows + nextCursor
+    Update(ctx context.Context, w Workspace) error
+    UpdateStatus(ctx context.Context, id WorkspaceID, status Status, statusError *Error, lastProbeAt time.Time) error
+    Delete(ctx context.Context, id WorkspaceID) error
+    Close(ctx context.Context) error
+}
+
+type ListOptions struct {
+    Namespace Namespace
+    AgentType AgentType
+    InfraType InfraType
+    Status    Status
+    Labels    map[string]string
+    Limit     int
+    Cursor    string
+}
+```
+
+Behavior rules:
+
+- `Insert` returns `ErrAliasConflict` if `(Namespace, Alias)` is taken;
+  the row is unchanged.
+- `UpdateStatus` is the **only** write that flips `Status`. All other
+  writes (e.g., `Update` for description / labels) MUST refuse to
+  change `Status` and return `ErrInvalidStatusTransition` on attempt
+  — the controller is the single owner of state changes.
+- `UpdateStatus` validates legal transitions per `DESIGN.md` §5.1:
+  - `init → healthy` ok.
+  - `init → failed` ok.
+  - `healthy → failed` ok.
+  - `failed → healthy` ok.
+  - `init → init` (idempotent on insert) ok.
+  - Any other transition returns `ErrInvalidStatusTransition`.
+- `List` returns rows sorted by `(Namespace, Alias)` ascending; the
+  cursor encodes the last seen row.
+- All methods are safe for concurrent use.
+
+Implementations:
+
+- `MemoryRepository` — reference, mutex-protected. Suitable for
+  tests and single-instance demos.
+- Production deployments supply a SQL-backed implementation and
+  inject it through `Builder.WorkspaceRepository`.
+
+## Controller
+
+The Controller is the workhorse that drives a `CreateWorkspace` /
+`DeleteWorkspace` from API entry to terminal status. It is owned by
+the manager root and reused across all callers.
+
+```go
+type Controller struct {
+    Repo          Repository
+    PluginStorage plugin.Storage
+    AgentSpecs    *agent.SpecSet
+    Factories     *infraops.FactorySet
+    Clock         func() time.Time
+    Logger        *slog.Logger
+
+    // tuning
+    InstallTimeout time.Duration // default 10 min
+    InstallWorkers int           // default 4
+    MaxPluginSize  int64         // default 256 MiB; enforced when
+                                 // expanding zips during install.
+}
+
+func (c *Controller) Start(ctx context.Context) error
+func (c *Controller) Stop(ctx context.Context) error
+
+// Submit enqueues a CreateWorkspace install run. The Workspace passed
+// in is already persisted in `init`. Submit returns immediately; the
+// install runs on a worker. ErrControllerShutdown if Stop has been
+// called.
+func (c *Controller) Submit(ctx context.Context, w Workspace, params agent.InstallParams) error
+
+// Delete tears down a Workspace synchronously. Errors that occur in
+// AgentSpec.Uninstall and InfraOps.Clear are logged but do not block
+// the eventual Repository.Delete call. Returns ErrWorkspaceNotFound
+// if the row is gone.
+func (c *Controller) Delete(ctx context.Context, id WorkspaceID) error
+
+// CountInflight reports the number of in-progress installs (for
+// tests and metrics).
+func (c *Controller) CountInflight() int
+```
+
+### Install worker pipeline
+
+For each `Submit(workspace, params)`:
+
+1. Acquire a slot in the worker pool (bounded by `InstallWorkers`).
+2. Build an install context derived from `c.installCtx` (cancelled by
+   `Stop`) with deadline `now + InstallTimeout`.
+3. Resolve `factory := c.Factories.Get(workspace.InfraType)`. If
+   missing, transition workspace to `failed` and return.
+4. Build `ops := factory(ctx, workspace.InfraOptions)`. Persist any
+   factory error to `failed`.
+5. `ops.Init(ctx)`. Persist `ErrAlreadyInitialized` and any other
+   `Init` error to `failed`.
+6. Resolve `spec := c.AgentSpecs.Get(workspace.AgentType)`. If
+   missing, persist `failed` (this should be unreachable because
+   the Manager validates the agent type at Submit time, but the
+   defensive check stays in case the registry is mutated mid-flight
+   by tests).
+7. For each `pluginRef` in `workspace.Plugins`:
+   a. `body, obj, err := c.PluginStorage.Get(ctx, pluginRef.PluginID)`.
+   b. `reader, err := plugin.OpenZipReaderFromStream(ctx, body, obj.Size, c.MaxPluginSize)`
+      (the helper buffers the stream and validates the manifest).
+   c. `placedPaths, err := spec.PluginLayout().Apply(ctx, ops,
+      reader.Manifest(), reader.FS())`.
+   d. Append `(pluginRef.PluginID, placedPaths)` to a result slice.
+   e. `reader.Close()`; defer `body.Close()`.
+   Any error in this loop transitions the workspace to `failed`.
+8. `spec.Install(ctx, ops, params)`. On error → `failed`.
+9. `result, err := spec.Probe(ctx, ops)`. If `err` or
+   `!result.Healthy`, transition to `failed` with the reported error.
+10. Persist the AttachedPlugins (with `placedPaths`) via
+    `Repository.Update`, then transition to `healthy` via
+    `Repository.UpdateStatus`.
+11. Release the worker pool slot.
+
+Cancellation:
+
+- `Stop` cancels `installCtx`. In-flight workers see ctx cancel,
+  flush the partial state to `failed`, and exit. `Stop` waits for
+  the worker pool to drain (bounded by the supplied `ctx`).
+- An individual install whose context exceeds `InstallTimeout`
+  transitions to `failed` with `ErrInstallTimeout`. The probe
+  scheduler also force-flips `init` workspaces older than
+  `InstallTimeout` (covers the case where the worker died without
+  writing).
+
+### Delete pipeline
+
+`Controller.Delete(ctx, id)`:
+
+1. `w, err := Repo.Get(ctx, id)`. If `ErrWorkspaceNotFound`, return
+   it.
+2. Build `factory`, then `ops := factory(ctx, w.InfraOptions)`.
+3. Resolve `spec := AgentSpecs.Get(w.AgentType)`.
+4. `spec.Uninstall(ctx, ops)` — log errors, continue.
+5. `ops.Clear(ctx)` — log errors, continue.
+6. `Repo.Delete(ctx, id)`. Returns nil even when steps 4/5 logged
+   errors.
+
+The Delete is **synchronous** because it is fast and operators want
+to know the row is gone before they re-create. If a backend grows
+slow `Uninstall` (e.g., draining a long-running daemon), v2 may
+introduce an async variant.
+
+## Probe scheduler
+
+```go
+type ProbeScheduler struct {
+    Repo       Repository
+    AgentSpecs *agent.SpecSet
+    Factories  *infraops.FactorySet
+    Clock      func() time.Time
+    Logger     *slog.Logger
+
+    Interval        time.Duration // default 30s
+    Workers         int           // default 4
+    Timeout         time.Duration // default 5s; per-probe ctx deadline
+    InstallTimeout  time.Duration // mirrors Controller; used to flip stuck `init`
+}
+
+func (s *ProbeScheduler) Start(ctx context.Context) error
+func (s *ProbeScheduler) Stop(ctx context.Context) error
+func (s *ProbeScheduler) Stats() ProbeStats
+```
+
+### Tick
+
+Every `Interval`:
+
+1. Call `Repo.List(opts={Statuses: [healthy, failed, init]})` in
+   pages.
+2. For each row:
+   a. If `Status == init` and `now - CreatedAt > InstallTimeout`,
+      transition to `failed` with `ErrInstallTimeout`.
+   b. If `Status in {healthy, failed}`, dispatch to a worker:
+      - Build `factory`, `ops := factory(ctx, row.InfraOptions)`.
+      - `result, err := spec.Probe(probeCtx, ops)`.
+      - Compute `newStatus := healthy` if `err == nil &&
+        result.Healthy`, else `failed`.
+      - If `newStatus != row.Status` OR result has new `Detail`,
+        `Repo.UpdateStatus(...)`.
+3. Wait for all worker goroutines for this tick to complete before
+   sleeping until the next tick.
+
+`probeCtx` is `ctx` from `Start` plus `WithTimeout(Timeout)`.
+
+### Concurrency
+
+- A workspace is probed by **at most one** worker per tick. The
+  scheduler dedups by `WorkspaceID` within a tick.
+- Workers across ticks may overlap if a tick takes longer than
+  `Interval`. The scheduler drops a tick rather than running two in
+  parallel: when the previous tick is still active at tick time,
+  log `slog.Warn(probe_overrun)` and skip.
+
+### Stats
+
+`ProbeStats` exposes counters for tests:
+
+```go
+type ProbeStats struct {
+    TicksRun        uint64
+    ProbesAttempted uint64
+    ProbesHealthy   uint64
+    ProbesFailed    uint64
+    Overruns        uint64
+}
+```
+
+## State machine
+
+Per `DESIGN.md` §5.1. The controller is the only writer of `init →
+{healthy, failed}`. The probe scheduler is the only writer of
+`{healthy ↔ failed}` and the only writer of `init → failed` via the
+install-timeout watchdog.
+
+```
+        Controller.Submit
+              │
+              ▼
+        ┌──────┐  install ok    ┌─────────┐
+        │ init ├──────────────▶ │ healthy │
+        └──┬───┘                └────┬────┘
+           │ install fail            │ probe fail
+           │     OR                  ▼
+           │ install timeout    ┌────────┐
+           ▼                    │ failed │
+        ┌────────┐ ◀────────────┤        │
+        │ failed │   (probe ok) └────────┘
+        └────────┘
+```
+
+Workspaces never have a "deleted" status; `Delete` removes the row.
+
+## Edge cases & decisions
+
+- **AgentType / InfraType disappears between Insert and install
+  worker.** Should not happen because the manager registers types
+  before accepting calls, but the worker still handles the missing
+  case gracefully by transitioning to `failed` with
+  `ErrAgentTypeUnknown` or `ErrInfraTypeUnknown`.
+- **PluginStorage.Get returns 404 mid-install.** Plugin was deleted
+  between submit and worker pickup. Workspace transitions to
+  `failed` with `ErrPluginNotFound`; partial files written so far
+  remain (cleanup happens at Delete).
+- **Repository write fails during install.** The worker logs the
+  error, retries the same write up to two times with exponential
+  backoff (250 ms / 750 ms), then gives up. The workspace is left
+  in its current persisted status; the next probe tick will pick
+  it up.
+- **Two CreateWorkspace calls race for the same alias.** The first
+  Insert wins; the second returns `ErrAliasConflict`. No worker is
+  scheduled for the loser.
+- **Probe scheduler started before Controller.** Allowed; the
+  scheduler will skip `init` rows until they age out (transitioning
+  them to `failed`), which is the correct behavior when the
+  controller never finishes them.
+- **Stop while installs are in-flight.** Each in-flight install
+  transitions its workspace to `failed{Code:"shutdown"}` and exits.
+  Workers drain before `Stop` returns. Restarting the manager
+  resumes from those `failed` rows; operators delete and recreate.
+
+## Tests to write (no implementation in this pass)
+
+1. `MemoryRepository` round-trip: Insert / Get / GetByAlias / List /
+   UpdateStatus / Delete.
+2. `Repository.UpdateStatus` rejects illegal transitions.
+3. `Controller.Submit` runs the canonical pipeline against a fake
+   `infraops` + fake `agent.AgentSpec` and lands `healthy`.
+4. `Controller.Submit` lands `failed` when `Install` returns an
+   error; `StatusError` populated.
+5. `Controller.Submit` honors `InstallTimeout`.
+6. `Controller.Delete` is idempotent against a missing row.
+7. `Controller.Delete` succeeds even when `Uninstall` errors.
+8. `ProbeScheduler` tick flips `healthy → failed` and back.
+9. `ProbeScheduler` flips stuck `init → failed` after
+   `InstallTimeout`.
+10. `ProbeScheduler` skips overrunning ticks and counts overruns.
+11. Concurrent `Controller.Submit` + `ProbeScheduler` under `-race`.
+
+## Out of scope
+
+- Async delete with a "deleting" status. v2.
+- Multi-instance manager coordination (leases, distributed
+  scheduling). v2.
+- Workspace **update** beyond labels/description (which `Update`
+  supports). Adding plugins to a live workspace is a v2 feature.
+- A separate "in-place reinstall" flow. Re-creation is the policy.


### PR DESCRIPTION
## Summary

- Add `pkg/manager/DESIGN.md` describing manager responsibilities, boundaries, and architecture.
- Add root `pkg/manager/AGENTS.md` plus per-area `AGENTS.md` and `PLAN.md` for agent, infraops (including localdir), plugin, and workspace.

## Test plan

- [x] `go test ./...`

Made with [Cursor](https://cursor.com)