### PR TITLE
feat: implement orchestrator leaf packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ go.work.sum
 .codex
 .vscode
 .cursor/settings.json
+.pro

--- a/docs/superpowers/plans/2026-05-11-orchestrator-leaf-packages.md
+++ b/docs/superpowers/plans/2026-05-11-orchestrator-leaf-packages.md
@@ -1,0 +1,460 @@
+# Orchestrator Leaf Packages Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement only the `pkg/orchestrator/idgen`, `pkg/orchestrator/protocol`, and `pkg/orchestrator/registry` leaf packages from the existing phase-1 design.
+
+**Architecture:** `idgen` and `protocol` remain layer-0 pure packages with no sibling orchestrator imports. `registry` remains a layer-0 catalog that imports the canonical `pkg/agentio` contract for `AgentFactory`, but never imports root orchestrator, engine, bridge packages, prompt, invoker, or agent runtime code. Each package gets focused tests before implementation.
+
+**Tech Stack:** Go 1.26.2, standard library only, `sync`, `sync/atomic`, `crypto/rand`, `regexp`, `errors`, and existing `github.com/AiRanthem/ANA/pkg/agentio`.
+
+---
+
+## File Structure
+
+- Create `pkg/orchestrator/idgen/idgen.go`: ID types, generator interface, sequential generator, default generator.
+- Create `pkg/orchestrator/idgen/idgen_test.go`: deterministic, uniqueness, category separation, concurrency tests.
+- Create `pkg/orchestrator/protocol/protocol.go`: Salutation parser, formatter helpers, sentinel error.
+- Create `pkg/orchestrator/protocol/protocol_test.go`: required valid, malformed, first-non-empty-line, and unknown-alias cases.
+- Create `pkg/orchestrator/registry/registry.go`: workspace model, runtime-kind enum, registry interface, memory registry.
+- Create `pkg/orchestrator/registry/registry_test.go`: lookup, alias collision, disabled/default behavior, failed registration rollback, concurrency tests.
+- Do not modify `pkg/orchestrator/engine.go`, `pkg/orchestrator/orchestrator.go`, `pkg/orchestrator/invoker/**`, `pkg/bridge/**`, `pkg/orchestrator/prompt/**`, or `pkg/agentio/**`.
+- Do not update `go.mod` or `go.sum`.
+- Do not update the three package `PLAN.md` files unless implementation behavior intentionally differs from the current plan; this plan follows the current `PLAN.md` files.
+
+## Task 1: Implement `idgen`
+
+**Files:**
+- Create: `pkg/orchestrator/idgen/idgen_test.go`
+- Create: `pkg/orchestrator/idgen/idgen.go`
+
+- [ ] **Step 1: Write the failing `idgen` tests**
+
+Create `pkg/orchestrator/idgen/idgen_test.go` with tests named:
+
+```go
+func TestSequentialGenerator_DeterministicIDs(t *testing.T)
+func TestSequentialGenerator_CategoriesDoNotCollide(t *testing.T)
+func TestSequentialGenerator_ConcurrentUseIsUnique(t *testing.T)
+func TestDefaultGenerator_ReturnsNonEmptyUniqueIDs(t *testing.T)
+```
+
+The tests must assert:
+
+```go
+g := NewSequential("T-")
+
+if got, want := g.NewTaskID(), TaskID("T-0000000001"); got != want {
+	t.Fatalf("NewTaskID() = %q, want %q", got, want)
+}
+if got, want := g.NewTaskID(), TaskID("T-0000000002"); got != want {
+	t.Fatalf("NewTaskID() = %q, want %q", got, want)
+}
+if got, want := g.NewSessionID(), SessionID("S-0000000001"); got != want {
+	t.Fatalf("NewSessionID() = %q, want %q", got, want)
+}
+if got, want := g.NewRequestID(), RequestID("R-0000000001"); got != want {
+	t.Fatalf("NewRequestID() = %q, want %q", got, want)
+}
+if got, want := g.NewEventID(), "E-0000000001"; got != want {
+	t.Fatalf("NewEventID() = %q, want %q", got, want)
+}
+```
+
+For category collision coverage, generate one task, session, request, and event ID from one sequential generator and assert the string set has length `4`.
+
+For default uniqueness coverage, use `NewDefault()` and generate at least 100 task IDs plus representative session, request, and event IDs. Assert no generated string is empty and no duplicate appears. Do not assert a concrete default ID format.
+
+- [ ] **Step 2: Run the `idgen` tests and confirm they fail**
+
+Run:
+
+```bash
+go test ./pkg/orchestrator/idgen
+```
+
+Expected: FAIL because `Generator`, `TaskID`, `SessionID`, `RequestID`, `NewSequential`, and `NewDefault` are not defined yet.
+
+- [ ] **Step 3: Implement `idgen.go`**
+
+Create `pkg/orchestrator/idgen/idgen.go` with this public surface and behavior:
+
+```go
+package idgen
+
+type TaskID string
+type SessionID string
+type RequestID string
+
+type Generator interface {
+	NewTaskID() TaskID
+	NewSessionID() SessionID
+	NewRequestID() RequestID
+	NewEventID() string
+}
+```
+
+Implementation requirements:
+
+- `NewSequential(prefix string) Generator` returns a concurrency-safe generator.
+- `NewSequential("T-").NewTaskID()` returns `T-0000000001`, then `T-0000000002`.
+- Sequential session, request, and event IDs always use `S-`, `R-`, and `E-`.
+- Sequential counters are independent per category and use `atomic.Uint64`.
+- `NewDefault() Generator` returns a concurrency-safe generator using only the standard library.
+- The default generator must produce non-empty unique opaque strings. Use a mutex-protected monotonic `time.Now().UnixNano()` component plus `crypto/rand` entropy. On entropy failure, panic with an error that includes `idgen default entropy`.
+
+Use this deterministic formatter:
+
+```go
+func formatSequential(prefix string, n uint64) string {
+	return fmt.Sprintf("%s%010d", prefix, n)
+}
+```
+
+- [ ] **Step 4: Run the `idgen` package tests**
+
+Run:
+
+```bash
+go test ./pkg/orchestrator/idgen
+```
+
+Expected: PASS.
+
+## Task 2: Implement `protocol`
+
+**Files:**
+- Create: `pkg/orchestrator/protocol/protocol_test.go`
+- Create: `pkg/orchestrator/protocol/protocol.go`
+
+- [ ] **Step 1: Write the failing `protocol` tests**
+
+Create `pkg/orchestrator/protocol/protocol_test.go` with tests named:
+
+```go
+func TestParseDirective_InlinePayload(t *testing.T)
+func TestParseDirective_MultilineBody(t *testing.T)
+func TestParseDirective_LeadingBlankLines(t *testing.T)
+func TestParseDirective_MalformedDirective(t *testing.T)
+func TestParseDirective_SecondNonEmptyLineIsPlainText(t *testing.T)
+func TestParseDirective_UnknownTargetReturnedAsAlias(t *testing.T)
+func TestFormat(t *testing.T)
+```
+
+Required assertions:
+
+- `"{to #Alice} check stock prices"` returns `RouteDirective{TargetAlias:"Alice", Payload:"check stock prices", IsExplicit:true, RawHeader:"{to #Alice} check stock prices"}`.
+- `"{to #Alice}\nline one\nline two"` returns target `Alice` and payload `"line one\nline two"`.
+- `"\n \n{to #Alice} hello"` treats `{to #Alice} hello` as the first non-empty line.
+- `"{to Alice}"`, `"{to #}"`, and `"{to #Alice"` each return an error matching `ErrInvalidRouteDirective`.
+- `"hello\n{to #Alice} later"` returns `IsExplicit=false`, empty `TargetAlias`, and payload equal to the original input.
+- `"{to #Unknown} ping"` returns target alias `Unknown`; registry lookup is not part of this package.
+
+- [ ] **Step 2: Run the `protocol` tests and confirm they fail**
+
+Run:
+
+```bash
+go test ./pkg/orchestrator/protocol
+```
+
+Expected: FAIL because `RouteDirective`, `ParseDirective`, `Format`, and `ErrInvalidRouteDirective` are not defined yet.
+
+- [ ] **Step 3: Implement `protocol.go`**
+
+Create `pkg/orchestrator/protocol/protocol.go` with:
+
+```go
+type RouteDirective struct {
+	TargetAlias string
+	Payload     string
+	IsExplicit  bool
+	RawHeader   string
+}
+
+var ErrInvalidRouteDirective = errors.New("invalid route directive")
+
+func ParseDirective(body string) (RouteDirective, error)
+func Format(alias string) string
+func ExampleHeader(alias string) string
+```
+
+Parser rules:
+
+- Normalize CRLF and lone CR to LF for explicit directive parsing.
+- Find the first line where `strings.TrimSpace(line) != ""`.
+- If no non-empty line exists, return `RouteDirective{Payload: body}` with no error.
+- Match only the first non-empty line against `^\s*\{to\s+#([A-Za-z0-9_-]{1,64})\}\s*(.*)$`.
+- If it matches, return:
+  - `TargetAlias` from the first capture group.
+  - `RawHeader` equal to the first non-empty line after newline normalization, without newline bytes.
+  - `IsExplicit=true`.
+  - `Payload` equal to the inline capture, the remaining body after the directive line, or both joined by one `\n`.
+- If it does not match and the first non-empty line begins with `{to` after leading whitespace and case-folding, return `ErrInvalidRouteDirective`.
+- If it does not look like an attempted directive, return `RouteDirective{Payload: body}` with no error.
+- Do not import `registry` or any sibling orchestrator package.
+
+- [ ] **Step 4: Run the `protocol` package tests**
+
+Run:
+
+```bash
+go test ./pkg/orchestrator/protocol
+```
+
+Expected: PASS.
+
+## Task 3: Implement `registry`
+
+**Files:**
+- Create: `pkg/orchestrator/registry/registry_test.go`
+- Create: `pkg/orchestrator/registry/registry.go`
+
+- [ ] **Step 1: Write the failing `registry` tests**
+
+Create `pkg/orchestrator/registry/registry_test.go` with tests named:
+
+```go
+func TestMemoryRegistry_RegisterAndLookupByID(t *testing.T)
+func TestMemoryRegistry_LookupByAlias(t *testing.T)
+func TestMemoryRegistry_AliasCollisionLeavesStateUnchanged(t *testing.T)
+func TestMemoryRegistry_DisabledWorkspaceLookup(t *testing.T)
+func TestMemoryRegistry_DefaultWorkspace(t *testing.T)
+func TestMemoryRegistry_MultipleDefaultRegistrationsDemotePrevious(t *testing.T)
+func TestMemoryRegistry_ConcurrentRegisterAndLookup(t *testing.T)
+func TestMemoryRegistry_FailedRegistrationLeavesRegistryUnchanged(t *testing.T)
+```
+
+Test helper shape:
+
+```go
+func testWorkspace(id, alias string) Workspace {
+	return Workspace{
+		WorkspaceID:   id,
+		Alias:         alias,
+		RuntimeType:   "cli",
+		RuntimeKind:   RuntimeKindResumableCLI,
+		Description:   "test workspace",
+		Enabled:       true,
+		RuntimeConfig: map[string]any{"path": "/tmp/agent"},
+	}
+}
+
+func testFactory(context.Context, Workspace) (agentio.Agent, error) {
+	return stubAgent{name: "test-agent"}, nil
+}
+
+type stubAgent struct {
+	name string
+}
+
+func (a stubAgent) Name() string { return a.name }
+func (a stubAgent) Invoke(context.Context, *agentio.InvokeRequest) (agentio.EventStream, error) {
+	return nil, errors.New("stub agent is not invoked by registry tests")
+}
+```
+
+Required assertions:
+
+- Lookup by ID and alias returns a copy of the registered workspace and a non-nil factory.
+- Alias collision returns an error matching `ErrAliasConflict`, keeps the original alias mapping, and does not add the failed workspace ID.
+- Disabled workspace lookup by ID and alias returns `ErrWorkspaceDisabled`.
+- `Default(ctx)` returns the explicit default workspace and factory.
+- Registering a second default demotes the previous default deterministically; the latest successful default is returned and the older workspace is still lookup-able with `IsDefaultEntry=false`.
+- Concurrent register and lookup uses unique IDs and aliases and passes under `go test -race`.
+- A failed registration with duplicate alias and `IsDefaultEntry=true` does not alter the previous default.
+
+- [ ] **Step 2: Run the `registry` tests and confirm they fail**
+
+Run:
+
+```bash
+go test ./pkg/orchestrator/registry
+```
+
+Expected: FAIL because `Workspace`, `RuntimeKindResumableCLI`, `NewMemory`, `ErrAliasConflict`, and related registry symbols are not defined yet.
+
+- [ ] **Step 3: Implement `registry.go`**
+
+Create `pkg/orchestrator/registry/registry.go` with this public surface:
+
+```go
+type RuntimeKind string
+
+const (
+	RuntimeKindChatAPI       RuntimeKind = "chat_api"
+	RuntimeKindResumableCLI  RuntimeKind = "resumable_cli"
+	RuntimeKindSocketSession RuntimeKind = "socket_session"
+)
+
+type Workspace struct {
+	WorkspaceID    string
+	Alias          string
+	RuntimeType    string
+	RuntimeKind    RuntimeKind
+	Description    string
+	Enabled        bool
+	IsDefaultEntry bool
+	RuntimeConfig  map[string]any
+}
+
+type AgentFactory func(ctx context.Context, ws Workspace) (agentio.Agent, error)
+
+type Registry interface {
+	Register(ctx context.Context, ws Workspace, factory AgentFactory) error
+	Update(ctx context.Context, ws Workspace) error
+	Disable(ctx context.Context, workspaceID string) error
+	Enable(ctx context.Context, workspaceID string) error
+	LookupByAlias(ctx context.Context, alias string) (Workspace, AgentFactory, error)
+	LookupByID(ctx context.Context, workspaceID string) (Workspace, AgentFactory, error)
+	Default(ctx context.Context) (Workspace, AgentFactory, error)
+	List(ctx context.Context) ([]Workspace, error)
+}
+```
+
+Sentinel errors:
+
+```go
+var (
+	ErrAliasNotFound     = errors.New("alias not found")
+	ErrWorkspaceNotFound = errors.New("workspace not found")
+	ErrWorkspaceDisabled = errors.New("workspace disabled")
+	ErrAliasConflict     = errors.New("alias conflict")
+	ErrInvalidWorkspace  = errors.New("invalid workspace")
+	ErrNoDefaultWorkspace = errors.New("no default workspace")
+)
+```
+
+Implementation requirements:
+
+- Provide `func NewMemory() *MemoryRegistry`.
+- Store `byID map[string]Workspace`, `byAlias map[string]string`, `factories map[string]AgentFactory`, and `defaultID string` under one `sync.RWMutex`.
+- Validate before mutating state:
+  - `WorkspaceID` non-empty after trimming for validation.
+  - `Alias` trimmed before storage, non-empty, length 1..64, matching `^[A-Za-z0-9_-]+$`.
+  - `RuntimeType` non-empty after trimming for validation.
+  - `RuntimeKind` one of the three constants.
+  - `Description` has at most 256 runes.
+  - `factory` is non-nil for `Register`.
+- `Register` must be transactional: validation and collision checks complete before any map write.
+- Duplicate workspace ID returns `ErrInvalidWorkspace` with context.
+- Duplicate alias returns `ErrAliasConflict` and leaves all maps and default state unchanged.
+- New default registration demotes the previous default by setting its stored `IsDefaultEntry=false`, then sets `defaultID` to the new workspace ID.
+- `LookupByID`, `LookupByAlias`, and `Default` return `ErrWorkspaceDisabled` for disabled workspaces.
+- `Disable` and `Enable` are idempotent for existing workspace IDs.
+- `List` returns all workspaces, enabled and disabled, sorted by alias for deterministic output.
+- Return cloned `Workspace` values with cloned `RuntimeConfig` maps.
+- Wrap stored factories so a factory returning `(nil, nil)` returns `ErrInvalidWorkspace` when invoked.
+- Do not import `pkg/bridge/...`, root `pkg/orchestrator`, `protocol`, `prompt`, `invoker`, or `agentio` subpackages other than canonical `pkg/agentio`.
+
+- [ ] **Step 4: Run the `registry` package tests**
+
+Run:
+
+```bash
+go test ./pkg/orchestrator/registry
+```
+
+Expected: PASS.
+
+## Task 4: Package Formatting And Focused Verification
+
+**Files:**
+- Verify only: `pkg/orchestrator/idgen/**`
+- Verify only: `pkg/orchestrator/protocol/**`
+- Verify only: `pkg/orchestrator/registry/**`
+
+- [ ] **Step 1: Format the three leaf packages**
+
+Run:
+
+```bash
+gofmt -s -w pkg/orchestrator/idgen pkg/orchestrator/protocol pkg/orchestrator/registry
+```
+
+Expected: no output.
+
+- [ ] **Step 2: Run focused package tests**
+
+Run:
+
+```bash
+go test ./pkg/orchestrator/idgen ./pkg/orchestrator/protocol ./pkg/orchestrator/registry
+```
+
+Expected: PASS for all three packages.
+
+- [ ] **Step 3: Run focused race tests**
+
+Run:
+
+```bash
+go test -race ./pkg/orchestrator/idgen ./pkg/orchestrator/protocol ./pkg/orchestrator/registry
+```
+
+Expected: PASS for all three packages.
+
+## Task 5: Full Repository Verification
+
+**Files:**
+- Verify only: entire repository
+
+- [ ] **Step 1: Run all tests**
+
+Run:
+
+```bash
+go test ./...
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run vet**
+
+Run:
+
+```bash
+go vet ./...
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run build**
+
+Run:
+
+```bash
+go build ./...
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Confirm scope**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected tracked changes are limited to:
+
+```text
+pkg/orchestrator/idgen/idgen.go
+pkg/orchestrator/idgen/idgen_test.go
+pkg/orchestrator/protocol/protocol.go
+pkg/orchestrator/protocol/protocol_test.go
+pkg/orchestrator/registry/registry.go
+pkg/orchestrator/registry/registry_test.go
+```
+
+This planning document may also appear if the implementation session includes the planning artifact. Existing unrelated `.gitignore` changes must remain untouched and must not be reverted.
+
+## Self-Review Checklist
+
+- Spec coverage: the plan covers all required `idgen`, `protocol`, and `registry` acceptance cases from `.pro/pro_context.md`.
+- Dependency coverage: `idgen` and `protocol` have no orchestrator sibling imports; `registry` imports only canonical `agentio` from existing code, never bridge.
+- Scope coverage: root engine, orchestrator, invoker, prompt, bridge, and agentio files are excluded.
+- Test coverage: focused tests, race tests, full tests, vet, and build are explicit.
+- Red-flag scan: no implementation step contains unresolved filler text.
+- Type consistency: names match `PLAN.md` and `DESIGN.md`: `TaskID`, `SessionID`, `RequestID`, `RouteDirective`, `RuntimeKind`, `Workspace`, `AgentFactory`, `Registry`, and the sentinel errors.

--- a/pkg/orchestrator/idgen/idgen.go
+++ b/pkg/orchestrator/idgen/idgen.go
@@ -1,0 +1,97 @@
+package idgen
+
+import (
+	"crypto/rand"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type TaskID string
+type SessionID string
+type RequestID string
+
+type Generator interface {
+	NewTaskID() TaskID
+	NewSessionID() SessionID
+	NewRequestID() RequestID
+	NewEventID() string
+}
+
+type sequentialGenerator struct {
+	taskCounter    atomic.Uint64
+	sessionCounter atomic.Uint64
+	requestCounter atomic.Uint64
+	eventCounter   atomic.Uint64
+	taskPrefix     string
+}
+
+type defaultGenerator struct {
+	mu           sync.Mutex
+	lastUnixNano int64
+}
+
+func NewSequential(prefix string) Generator {
+	return &sequentialGenerator{
+		taskPrefix: prefix,
+	}
+}
+
+func NewDefault() Generator {
+	return &defaultGenerator{}
+}
+
+func formatSequential(prefix string, n uint64) string {
+	return fmt.Sprintf("%s%010d", prefix, n)
+}
+
+func (g *sequentialGenerator) NewTaskID() TaskID {
+	return TaskID(formatSequential(g.taskPrefix, g.taskCounter.Add(1)))
+}
+
+func (g *sequentialGenerator) NewSessionID() SessionID {
+	return SessionID(formatSequential("S-", g.sessionCounter.Add(1)))
+}
+
+func (g *sequentialGenerator) NewRequestID() RequestID {
+	return RequestID(formatSequential("R-", g.requestCounter.Add(1)))
+}
+
+func (g *sequentialGenerator) NewEventID() string {
+	return formatSequential("E-", g.eventCounter.Add(1))
+}
+
+func (g *defaultGenerator) nextID() string {
+	g.mu.Lock()
+	now := time.Now().UnixNano()
+	if now <= g.lastUnixNano {
+		now = g.lastUnixNano + 1
+	}
+	g.lastUnixNano = now
+	g.mu.Unlock()
+
+	var entropy [5]byte
+	n, err := rand.Read(entropy[:])
+	if err != nil || n != len(entropy) {
+		panic(fmt.Sprintf("idgen default entropy: %v", err))
+	}
+
+	return fmt.Sprintf("%016x-%010x", uint64(now), entropy)
+}
+
+func (g *defaultGenerator) NewTaskID() TaskID {
+	return TaskID(g.nextID())
+}
+
+func (g *defaultGenerator) NewSessionID() SessionID {
+	return SessionID(g.nextID())
+}
+
+func (g *defaultGenerator) NewRequestID() RequestID {
+	return RequestID(g.nextID())
+}
+
+func (g *defaultGenerator) NewEventID() string {
+	return g.nextID()
+}

--- a/pkg/orchestrator/idgen/idgen.go
+++ b/pkg/orchestrator/idgen/idgen.go
@@ -1,3 +1,7 @@
+// Package idgen provides identifier generators for orchestrator entities such as
+// tasks, sessions, requests, and events. It exposes a deterministic sequential
+// generator suitable for tests and a production-oriented default generator that
+// combines a monotonic wall-clock component with crypto/rand entropy.
 package idgen
 
 import (
@@ -74,7 +78,7 @@ func (g *defaultGenerator) nextID() string {
 	var entropy [5]byte
 	n, err := rand.Read(entropy[:])
 	if err != nil || n != len(entropy) {
-		panic(fmt.Sprintf("idgen default entropy: %v", err))
+		panic(fmt.Errorf("idgen default entropy: %w", err))
 	}
 
 	return fmt.Sprintf("%016x-%010x", uint64(now), entropy)

--- a/pkg/orchestrator/idgen/idgen_test.go
+++ b/pkg/orchestrator/idgen/idgen_test.go
@@ -1,0 +1,255 @@
+package idgen
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestSequentialGenerator_DeterministicIDs(t *testing.T) {
+	t.Parallel()
+
+	generator := NewSequential("T-")
+
+	taskID1 := generator.NewTaskID()
+	taskID2 := generator.NewTaskID()
+	sessionID := generator.NewSessionID()
+	requestID := generator.NewRequestID()
+	eventID := generator.NewEventID()
+
+	if taskID1 != TaskID("T-0000000001") {
+		t.Fatalf("unexpected first task ID: %q", taskID1)
+	}
+	if taskID2 != TaskID("T-0000000002") {
+		t.Fatalf("unexpected second task ID: %q", taskID2)
+	}
+	if sessionID != SessionID("S-0000000001") {
+		t.Fatalf("unexpected session ID: %q", sessionID)
+	}
+	if requestID != RequestID("R-0000000001") {
+		t.Fatalf("unexpected request ID: %q", requestID)
+	}
+	if eventID != "E-0000000001" {
+		t.Fatalf("unexpected event ID: %q", eventID)
+	}
+}
+
+func TestSequentialGenerator_CategoriesDoNotCollide(t *testing.T) {
+	t.Parallel()
+
+	generator := NewSequential("T-")
+
+	ids := map[string]struct{}{
+		string(generator.NewTaskID()):    {},
+		string(generator.NewSessionID()): {},
+		string(generator.NewRequestID()): {},
+		generator.NewEventID():           {},
+	}
+
+	if len(ids) != 4 {
+		t.Fatalf("expected 4 unique IDs, got %d", len(ids))
+	}
+}
+
+func TestSequentialGenerator_ConcurrentUseIsUnique(t *testing.T) {
+	t.Parallel()
+
+	generator := NewSequential("T-")
+
+	const count = 100
+
+	ids := make(map[string]struct{}, count*4)
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	wg.Add(count * 4)
+
+	for i := 0; i < count; i++ {
+		go func() {
+			defer wg.Done()
+			id := string(generator.NewTaskID())
+			mu.Lock()
+			ids[id] = struct{}{}
+			mu.Unlock()
+		}()
+
+		go func() {
+			defer wg.Done()
+			id := string(generator.NewSessionID())
+			mu.Lock()
+			ids[id] = struct{}{}
+			mu.Unlock()
+		}()
+
+		go func() {
+			defer wg.Done()
+			id := string(generator.NewRequestID())
+			mu.Lock()
+			ids[id] = struct{}{}
+			mu.Unlock()
+		}()
+
+		go func() {
+			defer wg.Done()
+			id := generator.NewEventID()
+			mu.Lock()
+			ids[id] = struct{}{}
+			mu.Unlock()
+		}()
+	}
+
+	wg.Wait()
+
+	if len(ids) != count*4 {
+		t.Fatalf("expected %d unique IDs, got %d", count*4, len(ids))
+	}
+}
+
+func TestDefaultGenerator_ReturnsNonEmptyUniqueIDs(t *testing.T) {
+	t.Parallel()
+
+	generator := NewDefault()
+
+	ids := make(map[string]struct{}, 103)
+
+	for i := 0; i < 100; i++ {
+		id := string(generator.NewTaskID())
+		if id == "" {
+			t.Fatalf("empty task ID at index %d", i)
+		}
+
+		if _, exists := ids[id]; exists {
+			t.Fatalf("duplicated task ID at index %d", i)
+		}
+		ids[id] = struct{}{}
+	}
+
+	sessionID := string(generator.NewSessionID())
+	if sessionID == "" {
+		t.Fatal("empty session ID")
+	}
+	if _, exists := ids[sessionID]; exists {
+		t.Fatal("duplicated session ID")
+	}
+	ids[sessionID] = struct{}{}
+
+	requestID := string(generator.NewRequestID())
+	if requestID == "" {
+		t.Fatal("empty request ID")
+	}
+	if _, exists := ids[requestID]; exists {
+		t.Fatal("duplicated request ID")
+	}
+	ids[requestID] = struct{}{}
+
+	eventID := generator.NewEventID()
+	if eventID == "" {
+		t.Fatal("empty event ID")
+	}
+	if _, exists := ids[eventID]; exists {
+		t.Fatal("duplicated event ID")
+	}
+	ids[eventID] = struct{}{}
+}
+
+func TestDefaultGenerator_IDsAreASCIIAndReasonablySized(t *testing.T) {
+	t.Parallel()
+
+	generator := NewDefault()
+
+	for i := 0; i < 100; i++ {
+		id := string(generator.NewTaskID())
+		if len(id) < 26 || len(id) > 36 {
+			t.Fatalf("default task ID length out of range: %q (len=%d)", id, len(id))
+		}
+		for _, b := range []byte(id) {
+			if b > 127 {
+				t.Fatalf("default task ID contains non-ASCII byte: %q", b)
+			}
+		}
+	}
+}
+
+func TestDefaultGenerator_IDsIncreaseMonotonically(t *testing.T) {
+	t.Parallel()
+
+	generator := NewDefault()
+
+	previous := ""
+	for i := 0; i < 100; i++ {
+		current := string(generator.NewTaskID())
+		if i > 0 && current <= previous {
+			t.Fatalf("default task IDs are not lexicographically increasing: %q then %q", previous, current)
+		}
+		previous = current
+	}
+}
+
+func TestDefaultGenerator_ConcurrentUseIsUnique(t *testing.T) {
+	t.Parallel()
+
+	generator := NewDefault()
+
+	const count = 100
+
+	ids := make(map[string]struct{}, count*4)
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	wg.Add(count * 4)
+
+	for i := 0; i < count; i++ {
+		go func() {
+			defer wg.Done()
+			id := string(generator.NewTaskID())
+			if id == "" {
+				t.Error("empty task ID")
+				return
+			}
+			mu.Lock()
+			ids[id] = struct{}{}
+			mu.Unlock()
+		}()
+
+		go func() {
+			defer wg.Done()
+			id := string(generator.NewSessionID())
+			if id == "" {
+				t.Error("empty session ID")
+				return
+			}
+			mu.Lock()
+			ids[id] = struct{}{}
+			mu.Unlock()
+		}()
+
+		go func() {
+			defer wg.Done()
+			id := string(generator.NewRequestID())
+			if id == "" {
+				t.Error("empty request ID")
+				return
+			}
+			mu.Lock()
+			ids[id] = struct{}{}
+			mu.Unlock()
+		}()
+
+		go func() {
+			defer wg.Done()
+			id := generator.NewEventID()
+			if id == "" {
+				t.Error("empty event ID")
+				return
+			}
+			mu.Lock()
+			ids[id] = struct{}{}
+			mu.Unlock()
+		}()
+	}
+
+	wg.Wait()
+
+	if len(ids) != count*4 {
+		t.Fatalf("expected %d unique IDs, got %d", count*4, len(ids))
+	}
+}

--- a/pkg/orchestrator/protocol/protocol.go
+++ b/pkg/orchestrator/protocol/protocol.go
@@ -1,3 +1,6 @@
+// Package protocol parses and formats the explicit `{to #alias}` route directive
+// used by orchestrator messages. It is a layer-0 pure package: it does not
+// resolve aliases against the registry, only validates directive syntax.
 package protocol
 
 import (
@@ -84,6 +87,26 @@ func firstNonEmptyLineIndex(lines []string) int {
 }
 
 func appearsLikeDirective(line string) bool {
-	trimmed := strings.TrimLeft(line, " \t")
-	return strings.HasPrefix(strings.ToLower(trimmed), "{to")
+	// Match the leading whitespace class used by routeDirectiveRE (`\s` in Go
+	// regexp covers `[\t\n\f\r ]`). Lines are already split on `\n` and CR is
+	// normalized away, but trimming the rest keeps both code paths consistent.
+	trimmed := strings.TrimLeft(line, " \t\f")
+	lower := strings.ToLower(trimmed)
+	if !strings.HasPrefix(lower, "{to") {
+		return false
+	}
+	// Distinguish a real directive attempt (e.g. `{to #X}`, `{to}`, `{to#X}`)
+	// from plain text that incidentally starts with the letters "to"
+	// (e.g. `{tooling update}`, `{today}`). Only treat the line as an attempt
+	// when `{to` is followed by whitespace, `#`, `}`, or end of input.
+	rest := lower[len("{to"):]
+	if rest == "" {
+		return true
+	}
+	switch rest[0] {
+	case ' ', '\t', '\f', '#', '}':
+		return true
+	default:
+		return false
+	}
 }

--- a/pkg/orchestrator/protocol/protocol.go
+++ b/pkg/orchestrator/protocol/protocol.go
@@ -1,0 +1,89 @@
+package protocol
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// RouteDirective represents an optional explicit route directive in message text.
+type RouteDirective struct {
+	TargetAlias string
+	Payload     string
+	IsExplicit  bool
+	RawHeader   string
+}
+
+// ErrInvalidRouteDirective is returned when parsing appears to have an attempted
+// salutation but it does not match the strict directive grammar.
+var ErrInvalidRouteDirective = errors.New("invalid route directive")
+
+var routeDirectiveRE = regexp.MustCompile(`^\s*\{to\s+#([A-Za-z0-9_-]{1,64})\}\s*(.*)$`)
+
+// ParseDirective parses an input body for an explicit route directive.
+func ParseDirective(body string) (RouteDirective, error) {
+	normalized := normalizeLineEndings(body)
+	lines := strings.Split(normalized, "\n")
+
+	idx := firstNonEmptyLineIndex(lines)
+	if idx == -1 {
+		return RouteDirective{Payload: body}, nil
+	}
+
+	header := lines[idx]
+	if match := routeDirectiveRE.FindStringSubmatch(header); len(match) == 3 {
+		payloadLines := lines[idx+1:]
+		payload := match[2]
+		if len(payloadLines) > 0 {
+			if payload == "" {
+				payload = strings.Join(payloadLines, "\n")
+			} else {
+				payload = payload + "\n" + strings.Join(payloadLines, "\n")
+			}
+		}
+
+		return RouteDirective{
+			TargetAlias: match[1],
+			Payload:     payload,
+			IsExplicit:  true,
+			RawHeader:   header,
+		}, nil
+	}
+
+	if appearsLikeDirective(header) {
+		return RouteDirective{}, fmt.Errorf("parse directive: %w", ErrInvalidRouteDirective)
+	}
+
+	return RouteDirective{Payload: body}, nil
+}
+
+// Format renders a Salutation header for the given alias.
+func Format(alias string) string {
+	return "{to #" + alias + "}"
+}
+
+// ExampleHeader returns an example salutation header.
+func ExampleHeader(alias string) string {
+	return Format(alias)
+}
+
+func normalizeLineEndings(body string) string {
+	body = strings.ReplaceAll(body, "\r\n", "\n")
+	body = strings.ReplaceAll(body, "\r", "\n")
+	return body
+}
+
+func firstNonEmptyLineIndex(lines []string) int {
+	for i, line := range lines {
+		if strings.TrimSpace(line) != "" {
+			return i
+		}
+	}
+	return -1
+}
+
+func appearsLikeDirective(line string) bool {
+	trimmed := strings.TrimLeft(line, " \t")
+	return strings.HasPrefix(strings.ToLower(trimmed), "{to")
+}

--- a/pkg/orchestrator/protocol/protocol_test.go
+++ b/pkg/orchestrator/protocol/protocol_test.go
@@ -1,0 +1,218 @@
+package protocol
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestParseDirective_InlinePayload(t *testing.T) {
+	t.Parallel()
+
+	input := "{to #Alice} check stock prices"
+
+	got, err := ParseDirective(input)
+	if err != nil {
+		t.Fatalf("ParseDirective(%q): unexpected error: %v", input, err)
+	}
+
+	want := RouteDirective{
+		TargetAlias: "Alice",
+		Payload:     "check stock prices",
+		IsExplicit:  true,
+		RawHeader:   "{to #Alice} check stock prices",
+	}
+
+	if got != want {
+		t.Fatalf("ParseDirective(%q): got %#v, want %#v", input, got, want)
+	}
+}
+
+func TestParseDirective_MultilineBody(t *testing.T) {
+	t.Parallel()
+
+	input := "{to #Alice}\nline one\nline two"
+
+	got, err := ParseDirective(input)
+	if err != nil {
+		t.Fatalf("ParseDirective(%q): unexpected error: %v", input, err)
+	}
+
+	if got.TargetAlias != "Alice" {
+		t.Fatalf("TargetAlias: got %q, want %q", got.TargetAlias, "Alice")
+	}
+	if got.Payload != "line one\nline two" {
+		t.Fatalf("Payload: got %q, want %q", got.Payload, "line one\nline two")
+	}
+}
+
+func TestParseDirective_LeadingBlankLines(t *testing.T) {
+	t.Parallel()
+
+	input := "\n \n{to #Alice} hello"
+
+	got, err := ParseDirective(input)
+	if err != nil {
+		t.Fatalf("ParseDirective(%q): unexpected error: %v", input, err)
+	}
+
+	if !got.IsExplicit {
+		t.Fatalf("IsExplicit: got %v, want %v", got.IsExplicit, true)
+	}
+	if got.TargetAlias != "Alice" {
+		t.Fatalf("TargetAlias: got %q, want %q", got.TargetAlias, "Alice")
+	}
+}
+
+func TestParseDirective_MalformedDirective(t *testing.T) {
+	t.Parallel()
+
+	cases := []string{
+		"{to Alice}",
+		"{to #}",
+		"{to #Alice",
+	}
+
+	for _, input := range cases {
+		input := input
+		t.Run(input, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseDirective(input)
+			if !errors.Is(err, ErrInvalidRouteDirective) {
+				t.Fatalf("ParseDirective(%q): got err %v, want error Is ErrInvalidRouteDirective", input, err)
+			}
+		})
+	}
+}
+
+func TestParseDirective_SecondNonEmptyLineIsPlainText(t *testing.T) {
+	t.Parallel()
+
+	input := "hello\n{to #Alice} later"
+	got, err := ParseDirective(input)
+	if err != nil {
+		t.Fatalf("ParseDirective(%q): unexpected error: %v", input, err)
+	}
+
+	if got.IsExplicit {
+		t.Fatalf("IsExplicit: got %v, want %v", got.IsExplicit, false)
+	}
+	if got.TargetAlias != "" {
+		t.Fatalf("TargetAlias: got %q, want empty", got.TargetAlias)
+	}
+	if got.Payload != input {
+		t.Fatalf("Payload: got %q, want %q", got.Payload, input)
+	}
+}
+
+func TestParseDirective_UnknownTargetReturnedAsAlias(t *testing.T) {
+	t.Parallel()
+
+	input := "{to #Unknown} ping"
+	got, err := ParseDirective(input)
+	if err != nil {
+		t.Fatalf("ParseDirective(%q): unexpected error: %v", input, err)
+	}
+
+	if got.TargetAlias != "Unknown" {
+		t.Fatalf("TargetAlias: got %q, want %q", got.TargetAlias, "Unknown")
+	}
+	if got.RawHeader != input {
+		t.Fatalf("RawHeader: got %q, want %q", got.RawHeader, input)
+	}
+}
+
+func TestFormat(t *testing.T) {
+	t.Parallel()
+
+	got := Format("Alice")
+	if got != "{to #Alice}" {
+		t.Fatalf("Format(%q): got %q, want %q", "Alice", got, "{to #Alice}")
+	}
+	if ExampleHeader("Alice") != got {
+		t.Fatalf("ExampleHeader(%q): got %q, want %q", "Alice", ExampleHeader("Alice"), got)
+	}
+	if !strings.HasPrefix(got, "{to #") || !strings.HasSuffix(got, "}") {
+		t.Fatalf("Format(%q): malformed header %q", "Alice", got)
+	}
+}
+
+func TestParseDirective_NormalizesLineEndings(t *testing.T) {
+	t.Parallel()
+
+	t.Run("CRLF", func(t *testing.T) {
+		t.Parallel()
+
+		input := "{to #Alice}\r\nline one\r\nline two"
+		got, err := ParseDirective(input)
+		if err != nil {
+			t.Fatalf("ParseDirective(%q): unexpected error: %v", input, err)
+		}
+		if got.TargetAlias != "Alice" {
+			t.Fatalf("TargetAlias: got %q, want %q", got.TargetAlias, "Alice")
+		}
+		if got.Payload != "line one\nline two" {
+			t.Fatalf("Payload: got %q, want %q", got.Payload, "line one\nline two")
+		}
+	})
+
+	t.Run("CR", func(t *testing.T) {
+		t.Parallel()
+
+		input := "{to #Alice}\rbody"
+		got, err := ParseDirective(input)
+		if err != nil {
+			t.Fatalf("ParseDirective(%q): unexpected error: %v", input, err)
+		}
+		if got.TargetAlias != "Alice" {
+			t.Fatalf("TargetAlias: got %q, want %q", got.TargetAlias, "Alice")
+		}
+		if got.Payload != "body" {
+			t.Fatalf("Payload: got %q, want %q", got.Payload, "body")
+		}
+	})
+}
+
+func TestParseDirective_MalformedAlias(t *testing.T) {
+	t.Parallel()
+
+	t.Run("AliasContainsSpace", func(t *testing.T) {
+		t.Parallel()
+
+		input := "{to #al ice}"
+		_, err := ParseDirective(input)
+		if !errors.Is(err, ErrInvalidRouteDirective) {
+			t.Fatalf("ParseDirective(%q): got err %v, want error Is ErrInvalidRouteDirective", input, err)
+		}
+	})
+
+	t.Run("AliasTooLong", func(t *testing.T) {
+		t.Parallel()
+
+		input := "{to #" + strings.Repeat("a", 65) + "}"
+		_, err := ParseDirective(input)
+		if !errors.Is(err, ErrInvalidRouteDirective) {
+			t.Fatalf("ParseDirective(%q): got err %v, want error Is ErrInvalidRouteDirective", input, err)
+		}
+	})
+}
+
+func TestParseDirective_PlainTextFallback(t *testing.T) {
+	t.Parallel()
+
+	input := "plain message"
+	got, err := ParseDirective(input)
+	if err != nil {
+		t.Fatalf("ParseDirective(%q): unexpected error: %v", input, err)
+	}
+	if got.IsExplicit {
+		t.Fatalf("IsExplicit: got %v, want %v", got.IsExplicit, false)
+	}
+	if got.TargetAlias != "" {
+		t.Fatalf("TargetAlias: got %q, want empty", got.TargetAlias)
+	}
+	if got.Payload != input {
+		t.Fatalf("Payload: got %q, want %q", got.Payload, input)
+	}
+}

--- a/pkg/orchestrator/protocol/protocol_test.go
+++ b/pkg/orchestrator/protocol/protocol_test.go
@@ -198,6 +198,61 @@ func TestParseDirective_MalformedAlias(t *testing.T) {
 	})
 }
 
+func TestParseDirective_PlainTextWithToPrefixWord(t *testing.T) {
+	t.Parallel()
+
+	cases := []string{
+		"{tooling update}",
+		"{today is friday}",
+		"{tomato}",
+		"{to123}",
+		"{TOOLING}",
+	}
+
+	for _, input := range cases {
+		input := input
+		t.Run(input, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ParseDirective(input)
+			if err != nil {
+				t.Fatalf("ParseDirective(%q): unexpected error: %v", input, err)
+			}
+			if got.IsExplicit {
+				t.Fatalf("ParseDirective(%q): IsExplicit = true, want false", input)
+			}
+			if got.TargetAlias != "" {
+				t.Fatalf("ParseDirective(%q): TargetAlias = %q, want empty", input, got.TargetAlias)
+			}
+			if got.Payload != input {
+				t.Fatalf("ParseDirective(%q): Payload = %q, want %q", input, got.Payload, input)
+			}
+		})
+	}
+}
+
+func TestParseDirective_BareToAndAdjacentDirective(t *testing.T) {
+	t.Parallel()
+
+	cases := []string{
+		"{to",
+		"{to}",
+		"{to#Alice}",
+	}
+
+	for _, input := range cases {
+		input := input
+		t.Run(input, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseDirective(input)
+			if !errors.Is(err, ErrInvalidRouteDirective) {
+				t.Fatalf("ParseDirective(%q): got err %v, want error Is ErrInvalidRouteDirective", input, err)
+			}
+		})
+	}
+}
+
 func TestParseDirective_PlainTextFallback(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/orchestrator/registry/registry.go
+++ b/pkg/orchestrator/registry/registry.go
@@ -1,3 +1,9 @@
+// Package registry provides an in-memory catalog of orchestrator workspaces
+// keyed by both stable WorkspaceID and routable Alias, along with the
+// AgentFactory that produces an agentio.Agent for each entry. It is a layer-0
+// catalog: it imports only the canonical pkg/agentio contract and does not
+// depend on root orchestrator, engine, bridge, prompt, invoker, or agent
+// runtime packages.
 package registry
 
 import (
@@ -44,16 +50,49 @@ type Workspace struct {
 	RuntimeConfig  map[string]any
 }
 
+// AgentFactory builds an agentio.Agent for a registered workspace. Implementations
+// receive a defensive copy of the Workspace and must return a non-nil Agent on
+// success. The registry wraps stored factories so a (nil, nil) return surfaces
+// as ErrInvalidWorkspace.
 type AgentFactory func(ctx context.Context, ws Workspace) (agentio.Agent, error)
 
+// Registry is the catalog of workspaces and their AgentFactory bindings. All
+// methods are safe for concurrent use. The ctx parameter is currently unused
+// but reserved for future cancellation/tracing support.
 type Registry interface {
+	// Register stores a new workspace and its factory. Validation and collision
+	// checks complete before any state mutation; on conflict the registry is
+	// left unchanged.
 	Register(ctx context.Context, ws Workspace, factory AgentFactory) error
+
+	// Update replaces a stored workspace's mutable fields while preserving its
+	// AgentFactory binding. The Alias is immutable: an Update that changes it
+	// returns ErrInvalidWorkspace and leaves all state untouched. Setting
+	// IsDefaultEntry promotes this workspace and demotes any previous default;
+	// clearing it on the current default unsets the registry's default.
 	Update(ctx context.Context, ws Workspace) error
+
+	// Disable marks a workspace as disabled. Subsequent lookups return
+	// ErrWorkspaceDisabled. Idempotent for existing IDs.
 	Disable(ctx context.Context, workspaceID string) error
+
+	// Enable clears the disabled flag. Idempotent for existing IDs.
 	Enable(ctx context.Context, workspaceID string) error
+
+	// LookupByAlias returns a clone of the workspace and its wrapped factory.
+	// Returns ErrAliasNotFound or ErrWorkspaceDisabled when applicable.
 	LookupByAlias(ctx context.Context, alias string) (Workspace, AgentFactory, error)
+
+	// LookupByID returns a clone of the workspace and its wrapped factory.
+	// Returns ErrWorkspaceNotFound or ErrWorkspaceDisabled when applicable.
 	LookupByID(ctx context.Context, workspaceID string) (Workspace, AgentFactory, error)
+
+	// Default returns the workspace marked as the current default. Returns
+	// ErrNoDefaultWorkspace when no default has been set.
 	Default(ctx context.Context) (Workspace, AgentFactory, error)
+
+	// List returns clones of every registered workspace (enabled and disabled)
+	// sorted by Alias for deterministic output.
 	List(ctx context.Context) ([]Workspace, error)
 }
 
@@ -74,15 +113,15 @@ func NewMemory() *MemoryRegistry {
 }
 
 func (r *MemoryRegistry) Register(ctx context.Context, ws Workspace, factory AgentFactory) error {
-	_ = ctx
+	trimmedID := strings.TrimSpace(ws.WorkspaceID)
 
 	if factory == nil {
-		return fmt.Errorf("register workspace %q: %w", strings.TrimSpace(ws.WorkspaceID), ErrInvalidWorkspace)
+		return fmt.Errorf("register workspace %q: %w", trimmedID, ErrInvalidWorkspace)
 	}
 
 	normalized, err := validateWorkspace(ws)
 	if err != nil {
-		return fmt.Errorf("register workspace %q: %w", strings.TrimSpace(ws.WorkspaceID), err)
+		return fmt.Errorf("register workspace %q: %w", trimmedID, err)
 	}
 
 	r.mu.Lock()
@@ -115,8 +154,6 @@ func (r *MemoryRegistry) Register(ctx context.Context, ws Workspace, factory Age
 }
 
 func (r *MemoryRegistry) Update(ctx context.Context, ws Workspace) error {
-	_ = ctx
-
 	normalized, err := validateWorkspace(ws)
 	if err != nil {
 		return fmt.Errorf("update workspace %q: %w", strings.TrimSpace(ws.WorkspaceID), err)
@@ -152,8 +189,6 @@ func (r *MemoryRegistry) Update(ctx context.Context, ws Workspace) error {
 }
 
 func (r *MemoryRegistry) Disable(ctx context.Context, workspaceID string) error {
-	_ = ctx
-
 	trimmedID := strings.TrimSpace(workspaceID)
 
 	r.mu.Lock()
@@ -173,8 +208,6 @@ func (r *MemoryRegistry) Disable(ctx context.Context, workspaceID string) error 
 }
 
 func (r *MemoryRegistry) Enable(ctx context.Context, workspaceID string) error {
-	_ = ctx
-
 	trimmedID := strings.TrimSpace(workspaceID)
 
 	r.mu.Lock()
@@ -194,8 +227,6 @@ func (r *MemoryRegistry) Enable(ctx context.Context, workspaceID string) error {
 }
 
 func (r *MemoryRegistry) LookupByAlias(ctx context.Context, alias string) (Workspace, AgentFactory, error) {
-	_ = ctx
-
 	trimmedAlias := strings.TrimSpace(alias)
 
 	r.mu.RLock()
@@ -210,8 +241,6 @@ func (r *MemoryRegistry) LookupByAlias(ctx context.Context, alias string) (Works
 }
 
 func (r *MemoryRegistry) LookupByID(ctx context.Context, workspaceID string) (Workspace, AgentFactory, error) {
-	_ = ctx
-
 	trimmedID := strings.TrimSpace(workspaceID)
 
 	r.mu.RLock()
@@ -221,8 +250,6 @@ func (r *MemoryRegistry) LookupByID(ctx context.Context, workspaceID string) (Wo
 }
 
 func (r *MemoryRegistry) Default(ctx context.Context) (Workspace, AgentFactory, error) {
-	_ = ctx
-
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
@@ -234,8 +261,6 @@ func (r *MemoryRegistry) Default(ctx context.Context) (Workspace, AgentFactory, 
 }
 
 func (r *MemoryRegistry) List(ctx context.Context) ([]Workspace, error) {
-	_ = ctx
-
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
@@ -348,6 +373,11 @@ func cloneRuntimeValue(value any) any {
 	return cloneReflectValue(reflect.ValueOf(value)).Interface()
 }
 
+// cloneReflectValue produces a deep copy of value for use as a RuntimeConfig
+// payload. For exported struct fields it recurses; unexported fields are
+// shallow-copied (the same aliasing as `reflect.Value.Set`). This matches the
+// JSON-like data shape RuntimeConfig is intended to carry; embedding structs
+// with unexported mutable state will share those fields with the source.
 func cloneReflectValue(value reflect.Value) reflect.Value {
 	if !value.IsValid() {
 		return value
@@ -415,9 +445,8 @@ func cloneReflectValue(value reflect.Value) reflect.Value {
 }
 
 type runtimeValueRef struct {
-	typ  reflect.Type
-	kind reflect.Kind
-	ptr  uintptr
+	typ reflect.Type
+	ptr uintptr
 }
 
 func hasRuntimeConfigCycle(cfg map[string]any) bool {
@@ -443,7 +472,7 @@ func detectRuntimeConfigCycle(value reflect.Value, visiting, visited map[runtime
 		if value.IsNil() {
 			return false
 		}
-		ref := runtimeValueRef{typ: value.Type(), kind: value.Kind(), ptr: value.Pointer()}
+		ref := runtimeValueRef{typ: value.Type(), ptr: value.Pointer()}
 		if _, ok := visiting[ref]; ok {
 			return true
 		}
@@ -460,7 +489,7 @@ func detectRuntimeConfigCycle(value reflect.Value, visiting, visited map[runtime
 		if value.IsNil() {
 			return false
 		}
-		ref := runtimeValueRef{typ: value.Type(), kind: value.Kind(), ptr: value.Pointer()}
+		ref := runtimeValueRef{typ: value.Type(), ptr: value.Pointer()}
 		if _, ok := visiting[ref]; ok {
 			return true
 		}
@@ -486,7 +515,7 @@ func detectRuntimeConfigCycle(value reflect.Value, visiting, visited map[runtime
 		if value.IsNil() {
 			return false
 		}
-		ref := runtimeValueRef{typ: value.Type(), kind: value.Kind(), ptr: value.Pointer()}
+		ref := runtimeValueRef{typ: value.Type(), ptr: value.Pointer()}
 		if _, ok := visiting[ref]; ok {
 			return true
 		}

--- a/pkg/orchestrator/registry/registry.go
+++ b/pkg/orchestrator/registry/registry.go
@@ -1,0 +1,524 @@
+package registry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"unicode/utf8"
+
+	"github.com/AiRanthem/ANA/pkg/agentio"
+)
+
+type RuntimeKind string
+
+const (
+	RuntimeKindChatAPI       RuntimeKind = "chat_api"
+	RuntimeKindResumableCLI  RuntimeKind = "resumable_cli"
+	RuntimeKindSocketSession RuntimeKind = "socket_session"
+)
+
+var (
+	ErrAliasNotFound      = errors.New("alias not found")
+	ErrWorkspaceNotFound  = errors.New("workspace not found")
+	ErrWorkspaceDisabled  = errors.New("workspace disabled")
+	ErrAliasConflict      = errors.New("alias conflict")
+	ErrInvalidWorkspace   = errors.New("invalid workspace")
+	ErrNoDefaultWorkspace = errors.New("no default workspace")
+
+	aliasPattern = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+)
+
+type Workspace struct {
+	WorkspaceID    string
+	Alias          string
+	RuntimeType    string
+	RuntimeKind    RuntimeKind
+	Description    string
+	Enabled        bool
+	IsDefaultEntry bool
+	RuntimeConfig  map[string]any
+}
+
+type AgentFactory func(ctx context.Context, ws Workspace) (agentio.Agent, error)
+
+type Registry interface {
+	Register(ctx context.Context, ws Workspace, factory AgentFactory) error
+	Update(ctx context.Context, ws Workspace) error
+	Disable(ctx context.Context, workspaceID string) error
+	Enable(ctx context.Context, workspaceID string) error
+	LookupByAlias(ctx context.Context, alias string) (Workspace, AgentFactory, error)
+	LookupByID(ctx context.Context, workspaceID string) (Workspace, AgentFactory, error)
+	Default(ctx context.Context) (Workspace, AgentFactory, error)
+	List(ctx context.Context) ([]Workspace, error)
+}
+
+type MemoryRegistry struct {
+	mu        sync.RWMutex
+	byID      map[string]Workspace
+	byAlias   map[string]string
+	factories map[string]AgentFactory
+	defaultID string
+}
+
+func NewMemory() *MemoryRegistry {
+	return &MemoryRegistry{
+		byID:      make(map[string]Workspace),
+		byAlias:   make(map[string]string),
+		factories: make(map[string]AgentFactory),
+	}
+}
+
+func (r *MemoryRegistry) Register(ctx context.Context, ws Workspace, factory AgentFactory) error {
+	_ = ctx
+
+	if factory == nil {
+		return fmt.Errorf("register workspace %q: %w", strings.TrimSpace(ws.WorkspaceID), ErrInvalidWorkspace)
+	}
+
+	normalized, err := validateWorkspace(ws)
+	if err != nil {
+		return fmt.Errorf("register workspace %q: %w", strings.TrimSpace(ws.WorkspaceID), err)
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, exists := r.byID[normalized.WorkspaceID]; exists {
+		return fmt.Errorf("register workspace %q: duplicate workspace id: %w", normalized.WorkspaceID, ErrInvalidWorkspace)
+	}
+	if existingID, exists := r.byAlias[normalized.Alias]; exists {
+		return fmt.Errorf("register alias %q for workspace %q conflicts with workspace %q: %w", normalized.Alias, normalized.WorkspaceID, existingID, ErrAliasConflict)
+	}
+
+	normalized.RuntimeConfig = cloneRuntimeConfig(normalized.RuntimeConfig)
+	storedFactory := wrapFactory(factory)
+
+	if normalized.IsDefaultEntry && r.defaultID != "" && r.defaultID != normalized.WorkspaceID {
+		currentDefault := r.byID[r.defaultID]
+		currentDefault.IsDefaultEntry = false
+		r.byID[r.defaultID] = currentDefault
+	}
+
+	r.byID[normalized.WorkspaceID] = normalized
+	r.byAlias[normalized.Alias] = normalized.WorkspaceID
+	r.factories[normalized.WorkspaceID] = storedFactory
+	if normalized.IsDefaultEntry {
+		r.defaultID = normalized.WorkspaceID
+	}
+
+	return nil
+}
+
+func (r *MemoryRegistry) Update(ctx context.Context, ws Workspace) error {
+	_ = ctx
+
+	normalized, err := validateWorkspace(ws)
+	if err != nil {
+		return fmt.Errorf("update workspace %q: %w", strings.TrimSpace(ws.WorkspaceID), err)
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	existing, exists := r.byID[normalized.WorkspaceID]
+	if !exists {
+		return fmt.Errorf("update workspace %q: %w", normalized.WorkspaceID, ErrWorkspaceNotFound)
+	}
+	if normalized.Alias != existing.Alias {
+		return fmt.Errorf("update workspace %q alias %q: %w", normalized.WorkspaceID, normalized.Alias, ErrInvalidWorkspace)
+	}
+
+	normalized.RuntimeConfig = cloneRuntimeConfig(normalized.RuntimeConfig)
+
+	switch {
+	case normalized.IsDefaultEntry && r.defaultID != "" && r.defaultID != normalized.WorkspaceID:
+		currentDefault := r.byID[r.defaultID]
+		currentDefault.IsDefaultEntry = false
+		r.byID[r.defaultID] = currentDefault
+		r.defaultID = normalized.WorkspaceID
+	case normalized.IsDefaultEntry:
+		r.defaultID = normalized.WorkspaceID
+	case r.defaultID == normalized.WorkspaceID:
+		r.defaultID = ""
+	}
+
+	r.byID[normalized.WorkspaceID] = normalized
+	return nil
+}
+
+func (r *MemoryRegistry) Disable(ctx context.Context, workspaceID string) error {
+	_ = ctx
+
+	trimmedID := strings.TrimSpace(workspaceID)
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	ws, exists := r.byID[trimmedID]
+	if !exists {
+		return fmt.Errorf("disable workspace %q: %w", trimmedID, ErrWorkspaceNotFound)
+	}
+	if !ws.Enabled {
+		return nil
+	}
+
+	ws.Enabled = false
+	r.byID[trimmedID] = ws
+	return nil
+}
+
+func (r *MemoryRegistry) Enable(ctx context.Context, workspaceID string) error {
+	_ = ctx
+
+	trimmedID := strings.TrimSpace(workspaceID)
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	ws, exists := r.byID[trimmedID]
+	if !exists {
+		return fmt.Errorf("enable workspace %q: %w", trimmedID, ErrWorkspaceNotFound)
+	}
+	if ws.Enabled {
+		return nil
+	}
+
+	ws.Enabled = true
+	r.byID[trimmedID] = ws
+	return nil
+}
+
+func (r *MemoryRegistry) LookupByAlias(ctx context.Context, alias string) (Workspace, AgentFactory, error) {
+	_ = ctx
+
+	trimmedAlias := strings.TrimSpace(alias)
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	workspaceID, exists := r.byAlias[trimmedAlias]
+	if !exists {
+		return Workspace{}, nil, fmt.Errorf("lookup alias %q: %w", trimmedAlias, ErrAliasNotFound)
+	}
+
+	return r.lookupByIDLocked(workspaceID)
+}
+
+func (r *MemoryRegistry) LookupByID(ctx context.Context, workspaceID string) (Workspace, AgentFactory, error) {
+	_ = ctx
+
+	trimmedID := strings.TrimSpace(workspaceID)
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	return r.lookupByIDLocked(trimmedID)
+}
+
+func (r *MemoryRegistry) Default(ctx context.Context) (Workspace, AgentFactory, error) {
+	_ = ctx
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if r.defaultID == "" {
+		return Workspace{}, nil, ErrNoDefaultWorkspace
+	}
+
+	return r.lookupByIDLocked(r.defaultID)
+}
+
+func (r *MemoryRegistry) List(ctx context.Context) ([]Workspace, error) {
+	_ = ctx
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	workspaces := make([]Workspace, 0, len(r.byID))
+	for _, ws := range r.byID {
+		workspaces = append(workspaces, cloneWorkspace(ws))
+	}
+
+	sort.Slice(workspaces, func(i, j int) bool {
+		return workspaces[i].Alias < workspaces[j].Alias
+	})
+
+	return workspaces, nil
+}
+
+func (r *MemoryRegistry) lookupByIDLocked(workspaceID string) (Workspace, AgentFactory, error) {
+	ws, exists := r.byID[workspaceID]
+	if !exists {
+		return Workspace{}, nil, fmt.Errorf("lookup workspace %q: %w", workspaceID, ErrWorkspaceNotFound)
+	}
+	if !ws.Enabled {
+		return Workspace{}, nil, fmt.Errorf("lookup workspace %q: %w", workspaceID, ErrWorkspaceDisabled)
+	}
+
+	factory, exists := r.factories[workspaceID]
+	if !exists {
+		return Workspace{}, nil, fmt.Errorf("lookup workspace %q factory: %w", workspaceID, ErrInvalidWorkspace)
+	}
+
+	return cloneWorkspace(ws), factory, nil
+}
+
+func validateWorkspace(ws Workspace) (Workspace, error) {
+	normalized := ws
+	normalized.WorkspaceID = strings.TrimSpace(ws.WorkspaceID)
+	if normalized.WorkspaceID == "" {
+		return Workspace{}, ErrInvalidWorkspace
+	}
+
+	normalized.Alias = strings.TrimSpace(ws.Alias)
+	if normalized.Alias == "" {
+		return Workspace{}, ErrInvalidWorkspace
+	}
+	if len(normalized.Alias) > 64 {
+		return Workspace{}, ErrInvalidWorkspace
+	}
+	if !aliasPattern.MatchString(normalized.Alias) {
+		return Workspace{}, ErrInvalidWorkspace
+	}
+
+	normalized.RuntimeType = strings.TrimSpace(ws.RuntimeType)
+	if normalized.RuntimeType == "" {
+		return Workspace{}, ErrInvalidWorkspace
+	}
+
+	switch normalized.RuntimeKind {
+	case RuntimeKindChatAPI, RuntimeKindResumableCLI, RuntimeKindSocketSession:
+	default:
+		return Workspace{}, ErrInvalidWorkspace
+	}
+
+	if utf8.RuneCountInString(normalized.Description) > 256 {
+		return Workspace{}, ErrInvalidWorkspace
+	}
+
+	if hasRuntimeConfigCycle(normalized.RuntimeConfig) {
+		return Workspace{}, ErrInvalidWorkspace
+	}
+
+	normalized.RuntimeConfig = cloneRuntimeConfig(ws.RuntimeConfig)
+	return normalized, nil
+}
+
+func wrapFactory(factory AgentFactory) AgentFactory {
+	return func(ctx context.Context, ws Workspace) (agentio.Agent, error) {
+		agent, err := factory(ctx, cloneWorkspace(ws))
+		if err != nil {
+			return nil, err
+		}
+		if agent == nil {
+			return nil, fmt.Errorf("agent factory for workspace %q: %w", ws.WorkspaceID, ErrInvalidWorkspace)
+		}
+		return agent, nil
+	}
+}
+
+func cloneWorkspace(ws Workspace) Workspace {
+	clone := ws
+	clone.RuntimeConfig = cloneRuntimeConfig(ws.RuntimeConfig)
+	return clone
+}
+
+func cloneRuntimeConfig(cfg map[string]any) map[string]any {
+	if cfg == nil {
+		return nil
+	}
+
+	clone := make(map[string]any, len(cfg))
+	for key, value := range cfg {
+		clone[key] = cloneRuntimeValue(value)
+	}
+	return clone
+}
+
+func cloneRuntimeValue(value any) any {
+	if value == nil {
+		return nil
+	}
+
+	return cloneReflectValue(reflect.ValueOf(value)).Interface()
+}
+
+func cloneReflectValue(value reflect.Value) reflect.Value {
+	if !value.IsValid() {
+		return value
+	}
+
+	switch value.Kind() {
+	case reflect.Interface:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+
+		cloned := cloneReflectValue(value.Elem())
+		wrapped := reflect.New(value.Type()).Elem()
+		wrapped.Set(cloned)
+		return wrapped
+	case reflect.Ptr:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+
+		cloned := reflect.New(value.Type().Elem())
+		cloned.Elem().Set(cloneReflectValue(value.Elem()))
+		return cloned
+	case reflect.Map:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+
+		cloned := reflect.MakeMapWithSize(value.Type(), value.Len())
+		iter := value.MapRange()
+		for iter.Next() {
+			cloned.SetMapIndex(iter.Key(), cloneReflectValue(iter.Value()))
+		}
+		return cloned
+	case reflect.Slice:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+
+		cloned := reflect.MakeSlice(value.Type(), value.Len(), value.Len())
+		for i := range value.Len() {
+			cloned.Index(i).Set(cloneReflectValue(value.Index(i)))
+		}
+		return cloned
+	case reflect.Array:
+		cloned := reflect.New(value.Type()).Elem()
+		for i := range value.Len() {
+			cloned.Index(i).Set(cloneReflectValue(value.Index(i)))
+		}
+		return cloned
+	case reflect.Struct:
+		cloned := reflect.New(value.Type()).Elem()
+		cloned.Set(value)
+		for i := range value.NumField() {
+			field := cloned.Field(i)
+			if !field.CanSet() {
+				continue
+			}
+			field.Set(cloneReflectValue(value.Field(i)))
+		}
+		return cloned
+	default:
+		return value
+	}
+}
+
+type runtimeValueRef struct {
+	typ  reflect.Type
+	kind reflect.Kind
+	ptr  uintptr
+}
+
+func hasRuntimeConfigCycle(cfg map[string]any) bool {
+	if cfg == nil {
+		return false
+	}
+
+	return detectRuntimeConfigCycle(reflect.ValueOf(cfg), make(map[runtimeValueRef]struct{}), make(map[runtimeValueRef]struct{}))
+}
+
+func detectRuntimeConfigCycle(value reflect.Value, visiting, visited map[runtimeValueRef]struct{}) bool {
+	if !value.IsValid() {
+		return false
+	}
+
+	switch value.Kind() {
+	case reflect.Interface:
+		if value.IsNil() {
+			return false
+		}
+		return detectRuntimeConfigCycle(value.Elem(), visiting, visited)
+	case reflect.Ptr:
+		if value.IsNil() {
+			return false
+		}
+		ref := runtimeValueRef{typ: value.Type(), kind: value.Kind(), ptr: value.Pointer()}
+		if _, ok := visiting[ref]; ok {
+			return true
+		}
+		if _, ok := visited[ref]; ok {
+			return false
+		}
+		visiting[ref] = struct{}{}
+		defer func() {
+			delete(visiting, ref)
+			visited[ref] = struct{}{}
+		}()
+		return detectRuntimeConfigCycle(value.Elem(), visiting, visited)
+	case reflect.Map:
+		if value.IsNil() {
+			return false
+		}
+		ref := runtimeValueRef{typ: value.Type(), kind: value.Kind(), ptr: value.Pointer()}
+		if _, ok := visiting[ref]; ok {
+			return true
+		}
+		if _, ok := visited[ref]; ok {
+			return false
+		}
+		visiting[ref] = struct{}{}
+		defer func() {
+			delete(visiting, ref)
+			visited[ref] = struct{}{}
+		}()
+		iter := value.MapRange()
+		for iter.Next() {
+			if detectRuntimeConfigCycle(iter.Key(), visiting, visited) {
+				return true
+			}
+			if detectRuntimeConfigCycle(iter.Value(), visiting, visited) {
+				return true
+			}
+		}
+		return false
+	case reflect.Slice:
+		if value.IsNil() {
+			return false
+		}
+		ref := runtimeValueRef{typ: value.Type(), kind: value.Kind(), ptr: value.Pointer()}
+		if _, ok := visiting[ref]; ok {
+			return true
+		}
+		if _, ok := visited[ref]; ok {
+			return false
+		}
+		visiting[ref] = struct{}{}
+		defer func() {
+			delete(visiting, ref)
+			visited[ref] = struct{}{}
+		}()
+		for i := range value.Len() {
+			if detectRuntimeConfigCycle(value.Index(i), visiting, visited) {
+				return true
+			}
+		}
+		return false
+	case reflect.Array:
+		for i := range value.Len() {
+			if detectRuntimeConfigCycle(value.Index(i), visiting, visited) {
+				return true
+			}
+		}
+		return false
+	case reflect.Struct:
+		for i := range value.NumField() {
+			if detectRuntimeConfigCycle(value.Field(i), visiting, visited) {
+				return true
+			}
+		}
+		return false
+	default:
+		return false
+	}
+}

--- a/pkg/orchestrator/registry/registry_test.go
+++ b/pkg/orchestrator/registry/registry_test.go
@@ -1,0 +1,1197 @@
+package registry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/AiRanthem/ANA/pkg/agentio"
+)
+
+func TestMemoryRegistry_RegisterAndLookupByID(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	reg := NewMemory()
+	ws := testWorkspace("ws-alpha", "alpha")
+
+	if err := reg.Register(ctx, ws, testFactory("alpha-agent")); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	got, factory, err := reg.LookupByID(ctx, ws.WorkspaceID)
+	if err != nil {
+		t.Fatalf("LookupByID() error = %v", err)
+	}
+	if factory == nil {
+		t.Fatal("LookupByID() factory = nil")
+	}
+	if !reflect.DeepEqual(got, ws) {
+		t.Fatalf("LookupByID() workspace mismatch: got %#v want %#v", got, ws)
+	}
+
+	got.RuntimeConfig["path"] = "/tmp/changed"
+
+	again, againFactory, err := reg.LookupByID(ctx, ws.WorkspaceID)
+	if err != nil {
+		t.Fatalf("second LookupByID() error = %v", err)
+	}
+	if againFactory == nil {
+		t.Fatal("second LookupByID() factory = nil")
+	}
+	if again.RuntimeConfig["path"] != "/tmp/agent" {
+		t.Fatalf("RuntimeConfig clone was not preserved: got %v", again.RuntimeConfig["path"])
+	}
+}
+
+func TestMemoryRegistry_LookupByAlias(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	reg := NewMemory()
+	ws := testWorkspace("ws-bravo", "bravo")
+
+	if err := reg.Register(ctx, ws, testFactory("bravo-agent")); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	got, factory, err := reg.LookupByAlias(ctx, ws.Alias)
+	if err != nil {
+		t.Fatalf("LookupByAlias() error = %v", err)
+	}
+	if factory == nil {
+		t.Fatal("LookupByAlias() factory = nil")
+	}
+	if got.WorkspaceID != ws.WorkspaceID {
+		t.Fatalf("LookupByAlias() WorkspaceID = %q want %q", got.WorkspaceID, ws.WorkspaceID)
+	}
+}
+
+func TestMemoryRegistry_AliasCollisionLeavesStateUnchanged(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	reg := NewMemory()
+	original := testWorkspace("ws-charlie", "shared")
+
+	if err := reg.Register(ctx, original, testFactory("charlie-agent")); err != nil {
+		t.Fatalf("Register(original) error = %v", err)
+	}
+
+	collision := testWorkspace("ws-delta", "shared")
+	err := reg.Register(ctx, collision, testFactory("delta-agent"))
+	if !errors.Is(err, ErrAliasConflict) {
+		t.Fatalf("Register(collision) error = %v, want ErrAliasConflict", err)
+	}
+
+	got, _, err := reg.LookupByAlias(ctx, original.Alias)
+	if err != nil {
+		t.Fatalf("LookupByAlias(original) error = %v", err)
+	}
+	if got.WorkspaceID != original.WorkspaceID {
+		t.Fatalf("original alias remapped to %q want %q", got.WorkspaceID, original.WorkspaceID)
+	}
+
+	_, _, err = reg.LookupByID(ctx, collision.WorkspaceID)
+	if !errors.Is(err, ErrWorkspaceNotFound) {
+		t.Fatalf("LookupByID(collision) error = %v, want ErrWorkspaceNotFound", err)
+	}
+}
+
+func TestMemoryRegistry_DisabledWorkspaceLookup(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	reg := NewMemory()
+	ws := testWorkspace("ws-echo", "echo")
+
+	if err := reg.Register(ctx, ws, testFactory("echo-agent")); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	if err := reg.Disable(ctx, ws.WorkspaceID); err != nil {
+		t.Fatalf("Disable() error = %v", err)
+	}
+
+	_, _, err := reg.LookupByID(ctx, ws.WorkspaceID)
+	if !errors.Is(err, ErrWorkspaceDisabled) {
+		t.Fatalf("LookupByID() error = %v, want ErrWorkspaceDisabled", err)
+	}
+
+	_, _, err = reg.LookupByAlias(ctx, ws.Alias)
+	if !errors.Is(err, ErrWorkspaceDisabled) {
+		t.Fatalf("LookupByAlias() error = %v, want ErrWorkspaceDisabled", err)
+	}
+}
+
+func TestMemoryRegistry_ReenableRestoresLookups(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	reg := NewMemory()
+	ws := testWorkspace("ws-echo-reenable", "echo-reenable")
+
+	if err := reg.Register(ctx, ws, testFactory("echo-reenable-agent")); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	if err := reg.Disable(ctx, ws.WorkspaceID); err != nil {
+		t.Fatalf("Disable() error = %v", err)
+	}
+
+	_, _, err := reg.LookupByID(ctx, ws.WorkspaceID)
+	if !errors.Is(err, ErrWorkspaceDisabled) {
+		t.Fatalf("LookupByID() after Disable error = %v, want ErrWorkspaceDisabled", err)
+	}
+
+	if err := reg.Enable(ctx, ws.WorkspaceID); err != nil {
+		t.Fatalf("Enable() error = %v", err)
+	}
+
+	gotByID, factoryByID, err := reg.LookupByID(ctx, ws.WorkspaceID)
+	if err != nil {
+		t.Fatalf("LookupByID() after Enable error = %v", err)
+	}
+	if factoryByID == nil {
+		t.Fatal("LookupByID() after Enable factory = nil")
+	}
+	if gotByID.WorkspaceID != ws.WorkspaceID {
+		t.Fatalf("LookupByID() after Enable WorkspaceID = %q want %q", gotByID.WorkspaceID, ws.WorkspaceID)
+	}
+
+	gotByAlias, factoryByAlias, err := reg.LookupByAlias(ctx, ws.Alias)
+	if err != nil {
+		t.Fatalf("LookupByAlias() after Enable error = %v", err)
+	}
+	if factoryByAlias == nil {
+		t.Fatal("LookupByAlias() after Enable factory = nil")
+	}
+	if gotByAlias.WorkspaceID != ws.WorkspaceID {
+		t.Fatalf("LookupByAlias() after Enable WorkspaceID = %q want %q", gotByAlias.WorkspaceID, ws.WorkspaceID)
+	}
+}
+
+func TestMemoryRegistry_DefaultWorkspace(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	reg := NewMemory()
+	ws := testWorkspace("ws-foxtrot", "foxtrot")
+	ws.IsDefaultEntry = true
+
+	if err := reg.Register(ctx, ws, testFactory("foxtrot-agent")); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	got, factory, err := reg.Default(ctx)
+	if err != nil {
+		t.Fatalf("Default() error = %v", err)
+	}
+	if factory == nil {
+		t.Fatal("Default() factory = nil")
+	}
+	if !reflect.DeepEqual(got, ws) {
+		t.Fatalf("Default() workspace mismatch: got %#v want %#v", got, ws)
+	}
+}
+
+func TestMemoryRegistry_MultipleDefaultRegistrationsDemotePrevious(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	reg := NewMemory()
+	first := testWorkspace("ws-golf", "golf")
+	first.IsDefaultEntry = true
+	second := testWorkspace("ws-hotel", "hotel")
+	second.IsDefaultEntry = true
+
+	if err := reg.Register(ctx, first, testFactory("golf-agent")); err != nil {
+		t.Fatalf("Register(first) error = %v", err)
+	}
+	if err := reg.Register(ctx, second, testFactory("hotel-agent")); err != nil {
+		t.Fatalf("Register(second) error = %v", err)
+	}
+
+	gotDefault, _, err := reg.Default(ctx)
+	if err != nil {
+		t.Fatalf("Default() error = %v", err)
+	}
+	if gotDefault.WorkspaceID != second.WorkspaceID {
+		t.Fatalf("Default() WorkspaceID = %q want %q", gotDefault.WorkspaceID, second.WorkspaceID)
+	}
+
+	gotFirst, _, err := reg.LookupByID(ctx, first.WorkspaceID)
+	if err != nil {
+		t.Fatalf("LookupByID(first) error = %v", err)
+	}
+	if gotFirst.IsDefaultEntry {
+		t.Fatal("previous default remained marked as default")
+	}
+}
+
+func TestMemoryRegistry_ConcurrentRegisterAndLookup(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	reg := NewMemory()
+
+	const workers = 24
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, workers*2)
+
+	for i := range workers {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+
+			ws := testWorkspace(fmt.Sprintf("ws-%02d", i), fmt.Sprintf("alias-%02d", i))
+			if err := reg.Register(ctx, ws, testFactory(ws.Alias)); err != nil {
+				errCh <- fmt.Errorf("register %d: %w", i, err)
+				return
+			}
+
+			gotByID, _, err := reg.LookupByID(ctx, ws.WorkspaceID)
+			if err != nil {
+				errCh <- fmt.Errorf("lookup by id %d: %w", i, err)
+				return
+			}
+			if gotByID.Alias != ws.Alias {
+				errCh <- fmt.Errorf("lookup by id %d alias = %q want %q", i, gotByID.Alias, ws.Alias)
+				return
+			}
+
+			gotByAlias, _, err := reg.LookupByAlias(ctx, ws.Alias)
+			if err != nil {
+				errCh <- fmt.Errorf("lookup by alias %d: %w", i, err)
+				return
+			}
+			if gotByAlias.WorkspaceID != ws.WorkspaceID {
+				errCh <- fmt.Errorf("lookup by alias %d id = %q want %q", i, gotByAlias.WorkspaceID, ws.WorkspaceID)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestMemoryRegistry_FactoryErrorSurfacesUnchanged(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	reg := NewMemory()
+	ws := testWorkspace("ws-kilo", "kilo")
+	factoryErr := errors.New("factory failed")
+
+	if err := reg.Register(ctx, ws, func(ctx context.Context, ws Workspace) (agentio.Agent, error) {
+		return nil, factoryErr
+	}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	_, factory, err := reg.LookupByID(ctx, ws.WorkspaceID)
+	if err != nil {
+		t.Fatalf("LookupByID() error = %v", err)
+	}
+	if factory == nil {
+		t.Fatal("LookupByID() factory = nil")
+	}
+
+	agent, err := factory(ctx, ws)
+	if !errors.Is(err, factoryErr) {
+		t.Fatalf("factory() error = %v, want wrapped factoryErr", err)
+	}
+	if agent != nil {
+		t.Fatalf("factory() agent = %#v want nil", agent)
+	}
+}
+
+func TestMemoryRegistry_FailedRegistrationLeavesRegistryUnchanged(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	reg := NewMemory()
+	original := testWorkspace("ws-india", "india")
+	original.IsDefaultEntry = true
+
+	if err := reg.Register(ctx, original, testFactory("india-agent")); err != nil {
+		t.Fatalf("Register(original) error = %v", err)
+	}
+
+	collision := testWorkspace("ws-juliet", "india")
+	collision.IsDefaultEntry = true
+
+	err := reg.Register(ctx, collision, testFactory("juliet-agent"))
+	if !errors.Is(err, ErrAliasConflict) {
+		t.Fatalf("Register(collision) error = %v, want ErrAliasConflict", err)
+	}
+
+	gotDefault, _, err := reg.Default(ctx)
+	if err != nil {
+		t.Fatalf("Default() error = %v", err)
+	}
+	if gotDefault.WorkspaceID != original.WorkspaceID {
+		t.Fatalf("Default() WorkspaceID = %q want %q", gotDefault.WorkspaceID, original.WorkspaceID)
+	}
+
+	gotOriginal, _, err := reg.LookupByID(ctx, original.WorkspaceID)
+	if err != nil {
+		t.Fatalf("LookupByID(original) error = %v", err)
+	}
+	if !gotOriginal.IsDefaultEntry {
+		t.Fatal("original workspace lost default flag after failed registration")
+	}
+
+	_, _, err = reg.LookupByID(ctx, collision.WorkspaceID)
+	if !errors.Is(err, ErrWorkspaceNotFound) {
+		t.Fatalf("LookupByID(collision) error = %v, want ErrWorkspaceNotFound", err)
+	}
+}
+
+func TestMemoryRegistry_RegisterRejectsOversizedDescription(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	reg := NewMemory()
+	ws := testWorkspace("ws-lima", "lima")
+	ws.Description = strings.Repeat("x", 257)
+
+	err := reg.Register(ctx, ws, testFactory("lima-agent"))
+	if !errors.Is(err, ErrInvalidWorkspace) {
+		t.Fatalf("Register() error = %v, want ErrInvalidWorkspace", err)
+	}
+
+	_, _, err = reg.LookupByAlias(ctx, ws.Alias)
+	if !errors.Is(err, ErrAliasNotFound) {
+		t.Fatalf("LookupByAlias() error = %v, want ErrAliasNotFound", err)
+	}
+
+	_, _, err = reg.LookupByID(ctx, ws.WorkspaceID)
+	if !errors.Is(err, ErrWorkspaceNotFound) {
+		t.Fatalf("LookupByID() error = %v, want ErrWorkspaceNotFound", err)
+	}
+}
+
+func TestMemoryRegistry_RegisterRejectsBadAlias(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	reg := NewMemory()
+
+	for _, alias := range []string{"bad alias", "bad#alias"} {
+		t.Run(alias, func(t *testing.T) {
+			ws := testWorkspace("ws-"+alias, alias)
+
+			err := reg.Register(ctx, ws, testFactory("bad-alias-agent"))
+			if !errors.Is(err, ErrInvalidWorkspace) {
+				t.Fatalf("Register() error = %v, want ErrInvalidWorkspace", err)
+			}
+
+			_, _, err = reg.LookupByAlias(ctx, alias)
+			if !errors.Is(err, ErrAliasNotFound) {
+				t.Fatalf("LookupByAlias() error = %v, want ErrAliasNotFound", err)
+			}
+
+			_, _, err = reg.LookupByID(ctx, ws.WorkspaceID)
+			if !errors.Is(err, ErrWorkspaceNotFound) {
+				t.Fatalf("LookupByID() error = %v, want ErrWorkspaceNotFound", err)
+			}
+		})
+	}
+}
+
+func TestMemoryRegistry_FactoryWrapperRejectsNilAgent(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	reg := NewMemory()
+	ws := testWorkspace("ws-mike", "mike")
+
+	if err := reg.Register(ctx, ws, func(ctx context.Context, ws Workspace) (agentio.Agent, error) {
+		return nil, nil
+	}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	_, factory, err := reg.LookupByID(ctx, ws.WorkspaceID)
+	if err != nil {
+		t.Fatalf("LookupByID() error = %v", err)
+	}
+	if factory == nil {
+		t.Fatal("LookupByID() factory = nil")
+	}
+
+	agent, err := factory(ctx, ws)
+	if !errors.Is(err, ErrInvalidWorkspace) {
+		t.Fatalf("factory() error = %v, want ErrInvalidWorkspace", err)
+	}
+	if agent != nil {
+		t.Fatalf("factory() agent = %#v want nil", agent)
+	}
+}
+
+func TestMemoryRegistry_NestedRuntimeConfigCloneIsolation(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	reg := NewMemory()
+	ws := testWorkspace("ws-november", "november")
+	ws.RuntimeConfig = nestedRuntimeConfig()
+
+	if err := reg.Register(ctx, ws, testFactory("november-agent")); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	originalMeta := ws.RuntimeConfig["meta"].(map[string]any)
+	originalFlags := ws.RuntimeConfig["flags"].([]any)
+	originalLabels := ws.RuntimeConfig["labels"].([]string)
+
+	originalMeta["role"] = "mutated-after-register"
+	originalFlags[0] = "mutated-after-register"
+	originalLabels[0] = "mutated-after-register"
+
+	got, _, err := reg.LookupByID(ctx, ws.WorkspaceID)
+	if err != nil {
+		t.Fatalf("LookupByID() error = %v", err)
+	}
+	assertNestedConfigUnchanged(t, got.RuntimeConfig)
+
+	gotMeta := got.RuntimeConfig["meta"].(map[string]any)
+	gotFlags := got.RuntimeConfig["flags"].([]any)
+	gotLabels := got.RuntimeConfig["labels"].([]string)
+
+	gotMeta["role"] = "mutated-after-lookup"
+	gotFlags[0] = "mutated-after-lookup"
+	gotLabels[0] = "mutated-after-lookup"
+
+	again, _, err := reg.LookupByID(ctx, ws.WorkspaceID)
+	if err != nil {
+		t.Fatalf("second LookupByID() error = %v", err)
+	}
+	assertNestedConfigUnchanged(t, again.RuntimeConfig)
+
+	listed, err := reg.List(ctx)
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(listed) != 1 {
+		t.Fatalf("List() len = %d want 1", len(listed))
+	}
+	assertNestedConfigUnchanged(t, listed[0].RuntimeConfig)
+}
+
+func TestMemoryRegistry_FactoryInputCloneIsolation(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	reg := NewMemory()
+	ws := testWorkspace("ws-oscar", "oscar")
+	ws.RuntimeConfig = nestedRuntimeConfig()
+
+	if err := reg.Register(ctx, ws, func(ctx context.Context, ws Workspace) (agentio.Agent, error) {
+		ws.RuntimeConfig["meta"].(map[string]any)["role"] = "factory-mutated"
+		ws.RuntimeConfig["flags"].([]any)[0] = "factory-mutated"
+		ws.RuntimeConfig["labels"].([]string)[0] = "factory-mutated"
+		return stubAgent{name: "oscar-agent"}, nil
+	}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	_, factory, err := reg.LookupByID(ctx, ws.WorkspaceID)
+	if err != nil {
+		t.Fatalf("LookupByID() error = %v", err)
+	}
+
+	agent, err := factory(ctx, ws)
+	if err != nil {
+		t.Fatalf("factory() error = %v", err)
+	}
+	if agent == nil {
+		t.Fatal("factory() agent = nil")
+	}
+
+	got, _, err := reg.LookupByID(ctx, ws.WorkspaceID)
+	if err != nil {
+		t.Fatalf("LookupByID() after factory call error = %v", err)
+	}
+	assertNestedConfigUnchanged(t, got.RuntimeConfig)
+}
+
+func TestMemoryRegistry_UpdateRejectsAliasChangesAndLeavesAliasMapUnchanged(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	reg := NewMemory()
+	ws := testWorkspace("ws-papa", "papa")
+
+	if err := reg.Register(ctx, ws, testFactory("papa-agent")); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	updated := ws
+	updated.Alias = "quebec"
+
+	err := reg.Update(ctx, updated)
+	if !errors.Is(err, ErrInvalidWorkspace) {
+		t.Fatalf("Update() error = %v, want ErrInvalidWorkspace", err)
+	}
+
+	gotOriginal, _, err := reg.LookupByAlias(ctx, ws.Alias)
+	if err != nil {
+		t.Fatalf("LookupByAlias(original) error = %v", err)
+	}
+	if gotOriginal.WorkspaceID != ws.WorkspaceID {
+		t.Fatalf("LookupByAlias(original) WorkspaceID = %q want %q", gotOriginal.WorkspaceID, ws.WorkspaceID)
+	}
+
+	_, _, err = reg.LookupByAlias(ctx, updated.Alias)
+	if !errors.Is(err, ErrAliasNotFound) {
+		t.Fatalf("LookupByAlias(updated) error = %v, want ErrAliasNotFound", err)
+	}
+}
+
+func TestMemoryRegistry_UpdatePreservesFactory(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	reg := NewMemory()
+	ws := testWorkspace("ws-romeo", "romeo")
+	factory := testFactory("romeo-agent")
+
+	if err := reg.Register(ctx, ws, factory); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	updated := ws
+	updated.Description = "updated description"
+	updated.RuntimeConfig = nestedRuntimeConfig()
+
+	if err := reg.Update(ctx, updated); err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+
+	got, gotFactory, err := reg.LookupByID(ctx, ws.WorkspaceID)
+	if err != nil {
+		t.Fatalf("LookupByID() error = %v", err)
+	}
+	if got.Description != updated.Description {
+		t.Fatalf("LookupByID() Description = %q want %q", got.Description, updated.Description)
+	}
+	if gotFactory == nil {
+		t.Fatal("LookupByID() factory = nil")
+	}
+
+	agent, err := gotFactory(ctx, got)
+	if err != nil {
+		t.Fatalf("factory() error = %v", err)
+	}
+	if agent == nil {
+		t.Fatal("factory() agent = nil")
+	}
+	if agent.Name() != "romeo-agent" {
+		t.Fatalf("factory() agent.Name() = %q want %q", agent.Name(), "romeo-agent")
+	}
+}
+
+func TestMemoryRegistry_UpdatePromotesDefaultAndDemotesPrevious(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	reg := NewMemory()
+	first := testWorkspace("ws-sierra", "sierra")
+	first.IsDefaultEntry = true
+	second := testWorkspace("ws-tango", "tango")
+
+	if err := reg.Register(ctx, first, testFactory("sierra-agent")); err != nil {
+		t.Fatalf("Register(first) error = %v", err)
+	}
+	if err := reg.Register(ctx, second, testFactory("tango-agent")); err != nil {
+		t.Fatalf("Register(second) error = %v", err)
+	}
+
+	secondUpdated := second
+	secondUpdated.IsDefaultEntry = true
+
+	if err := reg.Update(ctx, secondUpdated); err != nil {
+		t.Fatalf("Update(second) error = %v", err)
+	}
+
+	gotDefault, _, err := reg.Default(ctx)
+	if err != nil {
+		t.Fatalf("Default() error = %v", err)
+	}
+	if gotDefault.WorkspaceID != second.WorkspaceID {
+		t.Fatalf("Default() WorkspaceID = %q want %q", gotDefault.WorkspaceID, second.WorkspaceID)
+	}
+
+	gotFirst, _, err := reg.LookupByID(ctx, first.WorkspaceID)
+	if err != nil {
+		t.Fatalf("LookupByID(first) error = %v", err)
+	}
+	if gotFirst.IsDefaultEntry {
+		t.Fatal("previous default remained marked after Update()")
+	}
+}
+
+func TestMemoryRegistry_FailedUpdateValidationLeavesStateUnchanged(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	reg := NewMemory()
+	original := testWorkspace("ws-uniform", "uniform")
+	original.Description = "before"
+	original.RuntimeConfig = nestedRuntimeConfig()
+
+	if err := reg.Register(ctx, original, testFactory("uniform-agent")); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	invalid := original
+	invalid.Description = strings.Repeat("x", 257)
+	invalid.RuntimeConfig["meta"].(map[string]any)["role"] = "changed-before-failed-update"
+
+	err := reg.Update(ctx, invalid)
+	if !errors.Is(err, ErrInvalidWorkspace) {
+		t.Fatalf("Update() error = %v, want ErrInvalidWorkspace", err)
+	}
+
+	got, _, err := reg.LookupByID(ctx, original.WorkspaceID)
+	if err != nil {
+		t.Fatalf("LookupByID() error = %v", err)
+	}
+	if got.Description != original.Description {
+		t.Fatalf("LookupByID() Description = %q want %q", got.Description, original.Description)
+	}
+	assertNestedConfigUnchanged(t, got.RuntimeConfig)
+}
+
+func TestMemoryRegistry_TypedNestedRuntimeConfigCloneIsolation(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	reg := NewMemory()
+	ws := testWorkspace("ws-victor", "victor")
+	ws.RuntimeConfig = typedRuntimeConfig()
+
+	if err := reg.Register(ctx, ws, testFactory("victor-agent")); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	originalBlob := ws.RuntimeConfig["blob"].([]byte)
+	originalCounts := ws.RuntimeConfig["counts"].(map[string]int)
+	originalGroups := ws.RuntimeConfig["groups"].(map[string][]string)
+	originalSteps := ws.RuntimeConfig["steps"].([]map[string]any)
+
+	originalBlob[0] = 'z'
+	originalCounts["ok"] = 99
+	originalGroups["team"][0] = "mutated-after-register"
+	originalSteps[0]["name"] = "mutated-after-register"
+
+	got, _, err := reg.LookupByID(ctx, ws.WorkspaceID)
+	if err != nil {
+		t.Fatalf("LookupByID() error = %v", err)
+	}
+	assertTypedConfigUnchanged(t, got.RuntimeConfig)
+
+	gotBlob := got.RuntimeConfig["blob"].([]byte)
+	gotCounts := got.RuntimeConfig["counts"].(map[string]int)
+	gotGroups := got.RuntimeConfig["groups"].(map[string][]string)
+	gotSteps := got.RuntimeConfig["steps"].([]map[string]any)
+
+	gotBlob[0] = 'y'
+	gotCounts["ok"] = 123
+	gotGroups["team"][0] = "mutated-after-lookup"
+	gotSteps[0]["name"] = "mutated-after-lookup"
+
+	again, _, err := reg.LookupByID(ctx, ws.WorkspaceID)
+	if err != nil {
+		t.Fatalf("second LookupByID() error = %v", err)
+	}
+	assertTypedConfigUnchanged(t, again.RuntimeConfig)
+}
+
+func TestMemoryRegistry_UpdateRuntimeConfigCloneIsolation(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	reg := NewMemory()
+	ws := testWorkspace("ws-whiskey", "whiskey")
+
+	if err := reg.Register(ctx, ws, testFactory("whiskey-agent")); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	updated := ws
+	updated.RuntimeConfig = typedRuntimeConfig()
+
+	if err := reg.Update(ctx, updated); err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+
+	updateBlob := updated.RuntimeConfig["blob"].([]byte)
+	updateCounts := updated.RuntimeConfig["counts"].(map[string]int)
+	updateGroups := updated.RuntimeConfig["groups"].(map[string][]string)
+	updateSteps := updated.RuntimeConfig["steps"].([]map[string]any)
+
+	updateBlob[0] = 'x'
+	updateCounts["ok"] = 77
+	updateGroups["team"][0] = "mutated-after-update"
+	updateSteps[0]["name"] = "mutated-after-update"
+
+	got, _, err := reg.LookupByID(ctx, ws.WorkspaceID)
+	if err != nil {
+		t.Fatalf("LookupByID() error = %v", err)
+	}
+	assertTypedConfigUnchanged(t, got.RuntimeConfig)
+}
+
+func TestMemoryRegistry_AliasTrimNormalization(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	reg := NewMemory()
+	ws := testWorkspace("ws-xray", "  xray  ")
+
+	if err := reg.Register(ctx, ws, testFactory("xray-agent")); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	gotTrimmed, _, err := reg.LookupByAlias(ctx, "xray")
+	if err != nil {
+		t.Fatalf("LookupByAlias(trimmed) error = %v", err)
+	}
+	if gotTrimmed.Alias != "xray" {
+		t.Fatalf("LookupByAlias(trimmed) Alias = %q want %q", gotTrimmed.Alias, "xray")
+	}
+
+	gotSpaced, _, err := reg.LookupByAlias(ctx, "  xray  ")
+	if err != nil {
+		t.Fatalf("LookupByAlias(spaced) error = %v", err)
+	}
+	if gotSpaced.Alias != "xray" {
+		t.Fatalf("LookupByAlias(spaced) Alias = %q want %q", gotSpaced.Alias, "xray")
+	}
+}
+
+func TestMemoryRegistry_PointerRuntimeConfigCloneIsolation(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	reg := NewMemory()
+	ws := testWorkspace("ws-bravo2", "bravo2")
+	ws.RuntimeConfig = map[string]any{
+		"object": newRuntimeConfigObject(),
+	}
+
+	if err := reg.Register(ctx, ws, testFactory("bravo2-agent")); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	originalObject := ws.RuntimeConfig["object"].(*runtimeConfigObject)
+	originalObject.Labels[0] = "mutated-after-register"
+	originalObject.Meta["role"] = "mutated-after-register"
+
+	got, _, err := reg.LookupByID(ctx, ws.WorkspaceID)
+	if err != nil {
+		t.Fatalf("LookupByID() error = %v", err)
+	}
+	assertPointerConfigObjectUnchanged(t, got.RuntimeConfig["object"])
+
+	gotObject := got.RuntimeConfig["object"].(*runtimeConfigObject)
+	gotObject.Labels[0] = "mutated-after-lookup"
+	gotObject.Meta["role"] = "mutated-after-lookup"
+
+	again, _, err := reg.LookupByID(ctx, ws.WorkspaceID)
+	if err != nil {
+		t.Fatalf("second LookupByID() error = %v", err)
+	}
+	assertPointerConfigObjectUnchanged(t, again.RuntimeConfig["object"])
+}
+
+func TestMemoryRegistry_StructRuntimeConfigCloneIsolation(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	reg := NewMemory()
+	ws := testWorkspace("ws-charlie2", "charlie2")
+	ws.RuntimeConfig = map[string]any{
+		"object": *newRuntimeConfigObject(),
+	}
+
+	if err := reg.Register(ctx, ws, testFactory("charlie2-agent")); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	originalObject := ws.RuntimeConfig["object"].(runtimeConfigObject)
+	originalObject.Labels[0] = "mutated-after-register"
+	originalObject.Meta["role"] = "mutated-after-register"
+
+	got, _, err := reg.LookupByID(ctx, ws.WorkspaceID)
+	if err != nil {
+		t.Fatalf("LookupByID() error = %v", err)
+	}
+	assertStructConfigObjectUnchanged(t, got.RuntimeConfig["object"])
+
+	gotObject := got.RuntimeConfig["object"].(runtimeConfigObject)
+	gotObject.Labels[0] = "mutated-after-lookup"
+	gotObject.Meta["role"] = "mutated-after-lookup"
+
+	again, _, err := reg.LookupByID(ctx, ws.WorkspaceID)
+	if err != nil {
+		t.Fatalf("second LookupByID() error = %v", err)
+	}
+	assertStructConfigObjectUnchanged(t, again.RuntimeConfig["object"])
+}
+
+func TestMemoryRegistry_FactoryInputCloneIsolationForPointerAndStructValues(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	reg := NewMemory()
+	ws := testWorkspace("ws-delta2", "delta2")
+	ws.RuntimeConfig = map[string]any{
+		"pointer": newRuntimeConfigObject(),
+		"struct":  *newRuntimeConfigObject(),
+	}
+
+	if err := reg.Register(ctx, ws, func(ctx context.Context, ws Workspace) (agentio.Agent, error) {
+		pointerObject := ws.RuntimeConfig["pointer"].(*runtimeConfigObject)
+		pointerObject.Labels[0] = "factory-mutated"
+		pointerObject.Meta["role"] = "factory-mutated"
+
+		structObject := ws.RuntimeConfig["struct"].(runtimeConfigObject)
+		structObject.Labels[0] = "factory-mutated"
+		structObject.Meta["role"] = "factory-mutated"
+
+		return stubAgent{name: "delta2-agent"}, nil
+	}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	_, factory, err := reg.LookupByID(ctx, ws.WorkspaceID)
+	if err != nil {
+		t.Fatalf("LookupByID() error = %v", err)
+	}
+	if factory == nil {
+		t.Fatal("LookupByID() factory = nil")
+	}
+
+	agent, err := factory(ctx, ws)
+	if err != nil {
+		t.Fatalf("factory() error = %v", err)
+	}
+	if agent == nil {
+		t.Fatal("factory() agent = nil")
+	}
+
+	got, _, err := reg.LookupByID(ctx, ws.WorkspaceID)
+	if err != nil {
+		t.Fatalf("LookupByID() after factory call error = %v", err)
+	}
+	assertPointerConfigObjectUnchanged(t, got.RuntimeConfig["pointer"])
+	assertStructConfigObjectUnchanged(t, got.RuntimeConfig["struct"])
+}
+
+func TestMemoryRegistry_RegisterRejectsCyclicRuntimeConfig(t *testing.T) {
+	if os.Getenv("ANA_REGISTRY_CYCLIC_REGISTER") == "1" {
+		ctx := context.Background()
+		reg := NewMemory()
+		original := testWorkspace("ws-yankee", "yankee")
+		if err := reg.Register(ctx, original, testFactory("yankee-agent")); err != nil {
+			t.Fatalf("Register(original) error = %v", err)
+		}
+
+		cyclic := testWorkspace("ws-zulu", "zulu")
+		cyclic.RuntimeConfig = cyclicMapRuntimeConfig()
+
+		err := reg.Register(ctx, cyclic, testFactory("zulu-agent"))
+		if !errors.Is(err, ErrInvalidWorkspace) {
+			t.Fatalf("Register(cyclic) error = %v, want ErrInvalidWorkspace", err)
+		}
+
+		gotOriginal, _, err := reg.LookupByID(ctx, original.WorkspaceID)
+		if err != nil {
+			t.Fatalf("LookupByID(original) error = %v", err)
+		}
+		if !reflect.DeepEqual(gotOriginal, original) {
+			t.Fatalf("LookupByID(original) = %#v want %#v", gotOriginal, original)
+		}
+
+		_, _, err = reg.LookupByID(ctx, cyclic.WorkspaceID)
+		if !errors.Is(err, ErrWorkspaceNotFound) {
+			t.Fatalf("LookupByID(cyclic) error = %v, want ErrWorkspaceNotFound", err)
+		}
+		return
+	}
+
+	runRegistrySubprocessTest(t, "ANA_REGISTRY_CYCLIC_REGISTER")
+}
+
+func TestMemoryRegistry_UpdateRejectsCyclicRuntimeConfig(t *testing.T) {
+	if os.Getenv("ANA_REGISTRY_CYCLIC_UPDATE") == "1" {
+		ctx := context.Background()
+		reg := NewMemory()
+		original := testWorkspace("ws-alpha2", "alpha2")
+		original.Description = "before"
+		if err := reg.Register(ctx, original, testFactory("alpha2-agent")); err != nil {
+			t.Fatalf("Register(original) error = %v", err)
+		}
+
+		updated := original
+		updated.Description = "after"
+		updated.RuntimeConfig = cyclicSliceRuntimeConfig()
+
+		err := reg.Update(ctx, updated)
+		if !errors.Is(err, ErrInvalidWorkspace) {
+			t.Fatalf("Update(cyclic) error = %v, want ErrInvalidWorkspace", err)
+		}
+
+		gotOriginal, _, err := reg.LookupByID(ctx, original.WorkspaceID)
+		if err != nil {
+			t.Fatalf("LookupByID(original) error = %v", err)
+		}
+		if gotOriginal.Description != original.Description {
+			t.Fatalf("LookupByID(original) Description = %q want %q", gotOriginal.Description, original.Description)
+		}
+		if !reflect.DeepEqual(gotOriginal.RuntimeConfig, original.RuntimeConfig) {
+			t.Fatalf("LookupByID(original) RuntimeConfig = %#v want %#v", gotOriginal.RuntimeConfig, original.RuntimeConfig)
+		}
+		return
+	}
+
+	runRegistrySubprocessTest(t, "ANA_REGISTRY_CYCLIC_UPDATE")
+}
+
+func testWorkspace(id, alias string) Workspace {
+	return Workspace{
+		WorkspaceID: id,
+		Alias:       alias,
+		RuntimeType: "cli",
+		RuntimeKind: RuntimeKindResumableCLI,
+		Description: "test workspace",
+		Enabled:     true,
+		RuntimeConfig: map[string]any{
+			"path": "/tmp/agent",
+		},
+	}
+}
+
+func testFactory(name string) AgentFactory {
+	return func(ctx context.Context, ws Workspace) (agentio.Agent, error) {
+		return stubAgent{name: name}, nil
+	}
+}
+
+type stubAgent struct {
+	name string
+}
+
+func (a stubAgent) Name() string {
+	return a.name
+}
+
+func (a stubAgent) Invoke(ctx context.Context, req *agentio.InvokeRequest) (agentio.EventStream, error) {
+	return nil, errors.New("stub invoke not implemented")
+}
+
+func nestedRuntimeConfig() map[string]any {
+	return map[string]any{
+		"path": "/tmp/agent",
+		"meta": map[string]any{
+			"role": "worker",
+		},
+		"flags":  []any{"alpha", true},
+		"labels": []string{"one", "two"},
+	}
+}
+
+func assertNestedConfigUnchanged(t *testing.T, cfg map[string]any) {
+	t.Helper()
+
+	meta, ok := cfg["meta"].(map[string]any)
+	if !ok {
+		t.Fatalf("meta type = %T want map[string]any", cfg["meta"])
+	}
+	if got := meta["role"]; got != "worker" {
+		t.Fatalf("meta.role = %v want worker", got)
+	}
+
+	flags, ok := cfg["flags"].([]any)
+	if !ok {
+		t.Fatalf("flags type = %T want []any", cfg["flags"])
+	}
+	if len(flags) != 2 {
+		t.Fatalf("flags len = %d want 2", len(flags))
+	}
+	if flags[0] != "alpha" {
+		t.Fatalf("flags[0] = %v want alpha", flags[0])
+	}
+	if flags[1] != true {
+		t.Fatalf("flags[1] = %v want true", flags[1])
+	}
+
+	labels, ok := cfg["labels"].([]string)
+	if !ok {
+		t.Fatalf("labels type = %T want []string", cfg["labels"])
+	}
+	if len(labels) != 2 {
+		t.Fatalf("labels len = %d want 2", len(labels))
+	}
+	if labels[0] != "one" {
+		t.Fatalf("labels[0] = %q want one", labels[0])
+	}
+	if labels[1] != "two" {
+		t.Fatalf("labels[1] = %q want two", labels[1])
+	}
+}
+
+func typedRuntimeConfig() map[string]any {
+	return map[string]any{
+		"path": "/tmp/agent",
+		"blob": []byte("abc"),
+		"counts": map[string]int{
+			"ok": 1,
+		},
+		"groups": map[string][]string{
+			"team": {"red", "blue"},
+		},
+		"steps": []map[string]any{
+			{"name": "prepare"},
+			{"name": "run"},
+		},
+	}
+}
+
+func assertTypedConfigUnchanged(t *testing.T, cfg map[string]any) {
+	t.Helper()
+
+	blob, ok := cfg["blob"].([]byte)
+	if !ok {
+		t.Fatalf("blob type = %T want []byte", cfg["blob"])
+	}
+	if string(blob) != "abc" {
+		t.Fatalf("blob = %q want %q", string(blob), "abc")
+	}
+
+	counts, ok := cfg["counts"].(map[string]int)
+	if !ok {
+		t.Fatalf("counts type = %T want map[string]int", cfg["counts"])
+	}
+	if counts["ok"] != 1 {
+		t.Fatalf("counts[\"ok\"] = %d want 1", counts["ok"])
+	}
+
+	groups, ok := cfg["groups"].(map[string][]string)
+	if !ok {
+		t.Fatalf("groups type = %T want map[string][]string", cfg["groups"])
+	}
+	team := groups["team"]
+	if len(team) != 2 {
+		t.Fatalf("groups[\"team\"] len = %d want 2", len(team))
+	}
+	if team[0] != "red" {
+		t.Fatalf("groups[\"team\"][0] = %q want red", team[0])
+	}
+	if team[1] != "blue" {
+		t.Fatalf("groups[\"team\"][1] = %q want blue", team[1])
+	}
+
+	steps, ok := cfg["steps"].([]map[string]any)
+	if !ok {
+		t.Fatalf("steps type = %T want []map[string]any", cfg["steps"])
+	}
+	if len(steps) != 2 {
+		t.Fatalf("steps len = %d want 2", len(steps))
+	}
+	if steps[0]["name"] != "prepare" {
+		t.Fatalf("steps[0][\"name\"] = %v want prepare", steps[0]["name"])
+	}
+	if steps[1]["name"] != "run" {
+		t.Fatalf("steps[1][\"name\"] = %v want run", steps[1]["name"])
+	}
+}
+
+func cyclicMapRuntimeConfig() map[string]any {
+	self := map[string]any{}
+	self["self"] = self
+	return self
+}
+
+func cyclicSliceRuntimeConfig() map[string]any {
+	self := make([]any, 1)
+	self[0] = self
+	return map[string]any{"self": self}
+}
+
+func runRegistrySubprocessTest(t *testing.T, envKey string) {
+	t.Helper()
+
+	cmd := exec.Command(os.Args[0], "-test.run=^"+t.Name()+"$")
+	cmd.Env = append(os.Environ(), envKey+"=1")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("subprocess failed: %v\n%s", err, output)
+	}
+}
+
+type runtimeConfigObject struct {
+	Labels []string
+	Meta   map[string]string
+}
+
+func newRuntimeConfigObject() *runtimeConfigObject {
+	return &runtimeConfigObject{
+		Labels: []string{"one", "two"},
+		Meta: map[string]string{
+			"role": "worker",
+		},
+	}
+}
+
+func assertPointerConfigObjectUnchanged(t *testing.T, value any) {
+	t.Helper()
+
+	object, ok := value.(*runtimeConfigObject)
+	if !ok {
+		t.Fatalf("object type = %T want *runtimeConfigObject", value)
+	}
+	assertRuntimeConfigObjectUnchanged(t, *object)
+}
+
+func assertStructConfigObjectUnchanged(t *testing.T, value any) {
+	t.Helper()
+
+	object, ok := value.(runtimeConfigObject)
+	if !ok {
+		t.Fatalf("object type = %T want runtimeConfigObject", value)
+	}
+	assertRuntimeConfigObjectUnchanged(t, object)
+}
+
+func assertRuntimeConfigObjectUnchanged(t *testing.T, object runtimeConfigObject) {
+	t.Helper()
+
+	if len(object.Labels) != 2 {
+		t.Fatalf("Labels len = %d want 2", len(object.Labels))
+	}
+	if object.Labels[0] != "one" {
+		t.Fatalf("Labels[0] = %q want one", object.Labels[0])
+	}
+	if object.Labels[1] != "two" {
+		t.Fatalf("Labels[1] = %q want two", object.Labels[1])
+	}
+	if object.Meta["role"] != "worker" {
+		t.Fatalf("Meta[\"role\"] = %q want worker", object.Meta["role"])
+	}
+}


### PR DESCRIPTION
Implemented phase 2 leaf packages for orchestrator: idgen, protocol, and registry.

- Added deterministic sequential and default ID generators with tests.
- Added strict route directive parsing for protocol with first-line-only detection and malformed fail-fast behavior.
- Implemented concurrent-safe in-memory registry with workspace registration/lookup, alias handling, default selection, enable/disable, update, and failure rollback semantics.
- Added comprehensive package tests covering required scenarios.

No changes were made to engine/orchestrator root, invoker, bridge, prompt, or agentio packages.