### PR TITLE
feat(orchestrator): add audit sink and event bus packages

### DIFF
--- a/docs/superpowers/plans/2026-05-12-audit-events-review-fixes.md
+++ b/docs/superpowers/plans/2026-05-12-audit-events-review-fixes.md
@@ -1,0 +1,805 @@
+# Audit / Events Review Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve the 9 issues identified by the code review of `pkg/orchestrator/audit` and `pkg/orchestrator/events`: align DESIGN/PLAN documents with the implementation, unify the `Seq` field type across both packages, document leaked API surface, fix one tautological test, harden one flaky test, fix the multi-sink Close semantics, and add the missing ordering tests.
+
+**Architecture:** All changes are either (a) doc edits to `DESIGN.md` / `PLAN.md`, (b) localized fixes inside the two leaf packages `pkg/orchestrator/audit` and `pkg/orchestrator/events`, or (c) test additions/edits in the same two packages. No new dependencies, no public-interface breakage beyond a single integer-width change (`int` → `uint64`) on a field that has no in-tree callers yet.
+
+**Tech Stack:** Go (stdlib only), `github.com/AiRanthem/ANA/pkg/orchestrator/idgen` for ID types.
+
+---
+
+## File Map
+
+- Modify: `pkg/orchestrator/DESIGN.md` (§8.2 Event schema — add `Seq`)
+- Modify: `pkg/orchestrator/audit/PLAN.md` (public surface — declare `ErrNoSink`; record table — add `Seq`)
+- Modify: `pkg/orchestrator/events/PLAN.md` (public surface — declare `Dropped()`; Drop policy — describe inline coalescing; `Publish` semantics on empty TaskID)
+- Modify: `pkg/orchestrator/audit/audit.go` (change `EventRecord.Seq` from `int` to `uint64`; add EventType sync comment; fix `multiSink.Close` zero-sink behavior)
+- Modify: `pkg/orchestrator/audit/audit_test.go` (update Seq types in test helpers; fix `TestFailingSinkReturnsErrorToCaller` to go through `Multi`; add transcript ordering test)
+- Modify: `pkg/orchestrator/events/events.go` (add EventType sync comment)
+- Modify: `pkg/orchestrator/events/events_test.go` (harden `TestBus_ConcurrentPublishSubscribe` buffer; add multi-event ordering test)
+
+---
+
+## Task 1: Document the `Seq` field in DESIGN.md §8.2
+
+**Files:**
+- Modify: `pkg/orchestrator/DESIGN.md:723-733`
+
+Background: The `Event` struct in code carries a `Seq` field used for per-task monotonic ordering, but DESIGN.md §8.2 omits it. AGENTS.md requires DESIGN updates for event-taxonomy changes.
+
+- [ ] **Step 1: Update the Event struct in DESIGN.md**
+
+Replace lines 723-733 of `pkg/orchestrator/DESIGN.md`:
+
+```go
+type Event struct {
+    EventID    string
+    TaskID     TaskID
+    SessionID  SessionID  // empty when type == task.*
+    RequestID  RequestID  // empty when type == task.* / session.*
+    Type       EventType
+    Seq        uint64     // monotonic per (task, session, request); audit and bus use the same width
+    OccurredAt time.Time
+    Payload    EventPayload // typed per Type
+}
+```
+
+- [ ] **Step 2: Verify the file still reads coherently**
+
+Run: `grep -n "Seq" pkg/orchestrator/DESIGN.md`
+Expected: at least one match showing `Seq` inside the Event struct block; surrounding prose (`The full type list…`) unchanged.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pkg/orchestrator/DESIGN.md
+git commit -m "docs(orchestrator): add Seq to Event schema in DESIGN §8.2"
+```
+
+---
+
+## Task 2: Unify `Seq` type to `uint64` in `audit.EventRecord`
+
+**Files:**
+- Modify: `pkg/orchestrator/audit/audit.go:62-72`
+- Modify: `pkg/orchestrator/audit/audit_test.go:405-417` (test helper `testEvent`)
+
+Background: `events.Event.Seq` is `uint64`, `audit.EventRecord.Seq` is `int`. Same logical field, different widths — any future bridge code will need explicit conversion and lose negative-value safety. Pick `uint64` to match the bus.
+
+- [ ] **Step 1: Change the EventRecord struct in audit.go**
+
+In `pkg/orchestrator/audit/audit.go`, change the `Seq` field type:
+
+```go
+type EventRecord struct {
+    EventID    string
+    TaskID     idgen.TaskID
+    SessionID  idgen.SessionID
+    RequestID  idgen.RequestID
+    Type       EventType
+    Seq        uint64
+    OccurredAt time.Time
+    Payload    []byte
+    Schema     string
+}
+```
+
+- [ ] **Step 2: Adjust the `TranscriptRecord.Seq` field for consistency**
+
+Same file, `TranscriptRecord.Seq` is also `int`. Change to `uint64`:
+
+```go
+type TranscriptRecord struct {
+    TaskID      idgen.TaskID
+    SessionID   idgen.SessionID
+    RequestID   idgen.RequestID
+    Kind        TranscriptKind
+    Content     []byte
+    ContentType string
+    Seq         uint64
+    Schema      string
+    CreatedAt   time.Time
+}
+```
+
+- [ ] **Step 3: Adjust the `NewInputTranscript` / `NewOutputTranscript` / `NewEventSummaryTranscript` signatures**
+
+In the same file, change each constructor's `seq int` parameter to `seq uint64`:
+
+```go
+func NewInputTranscript(request FullyRenderedRequest, seq uint64, createdAt time.Time) (TranscriptRecord, error) {
+    // body unchanged
+}
+
+func NewOutputTranscript(taskID idgen.TaskID, sessionID idgen.SessionID, requestID idgen.RequestID, output string, seq uint64, createdAt time.Time) TranscriptRecord {
+    // body unchanged
+}
+
+func NewEventSummaryTranscript(taskID idgen.TaskID, sessionID idgen.SessionID, requestID idgen.RequestID, summary any, seq uint64, createdAt time.Time) (TranscriptRecord, error) {
+    // body unchanged
+}
+```
+
+- [ ] **Step 4: Adjust error format strings that print `Seq`**
+
+The two `WriteTranscript` error messages and the two `multiSink.WriteTranscript` wrappers use `%d` for `Seq`. `%d` is correct for `uint64` too, so no change needed — verify:
+
+Run: `grep -n "kind %q seq %d" pkg/orchestrator/audit/audit.go`
+Expected: 4 lines, all unchanged.
+
+- [ ] **Step 5: Update the `testEvent` helper in audit_test.go**
+
+In `pkg/orchestrator/audit/audit_test.go`, change the `seq int` parameter to `seq uint64`:
+
+```go
+func testEvent(taskID idgen.TaskID, typ EventType, seq uint64) EventRecord {
+    return EventRecord{
+        EventID:    fmt.Sprintf("event-%d", seq),
+        TaskID:     taskID,
+        SessionID:  "session-1",
+        RequestID:  "request-1",
+        Type:       typ,
+        Seq:        seq,
+        OccurredAt: time.Unix(0, int64(seq)),
+        Payload:    []byte(`{"ok":true}`),
+        Schema:     SchemaV1,
+    }
+}
+```
+
+- [ ] **Step 6: Update `TestMemorySink_ConcurrentWritesAreSafe` call sites**
+
+Same file, in `TestMemorySink_ConcurrentWritesAreSafe` (lines 364-390), the inner loop builds an `int` and passes it to `testEvent`. Update both inner expressions:
+
+```go
+for seq := range writesPerWriter {
+    record := testEvent(taskID, EventTypeRequestTextChunk, uint64(writer*writesPerWriter+seq))
+    if err := sink.WriteEvent(ctx, record); err != nil {
+        t.Errorf("WriteEvent() error = %v", err)
+    }
+}
+```
+
+- [ ] **Step 7: Update `TestFailingSinkReturnsErrorToCaller` literal `Seq: 1`**
+
+Same file, the literal `Seq: 1` at line ~99 is implicitly typed — no source change required, but verify the file compiles.
+
+- [ ] **Step 8: Run audit tests**
+
+Run: `go test ./pkg/orchestrator/audit/... -race`
+Expected: all tests pass; no `int` / `uint64` mismatch errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add pkg/orchestrator/audit/audit.go pkg/orchestrator/audit/audit_test.go
+git commit -m "refactor(audit): unify Seq field type to uint64 across audit and events"
+```
+
+---
+
+## Task 3: Add `Seq` to audit/PLAN.md record-shape tables
+
+**Files:**
+- Modify: `pkg/orchestrator/audit/PLAN.md:70-79`
+
+- [ ] **Step 1: Add Seq row to the EventRecord table**
+
+In `pkg/orchestrator/audit/PLAN.md`, the EventRecord table currently has 8 rows. Insert a `Seq` row after `Type`:
+
+```markdown
+| Field        | Type        | Notes |
+|--------------|-------------|-------|
+| `EventID`    | `string`    | Globally unique; generated by `idgen` |
+| `TaskID`     | `TaskID`    |       |
+| `SessionID`  | `SessionID` | Empty for `task.*` events |
+| `RequestID`  | `RequestID` | Empty for `task.*` and `session.*` events |
+| `Type`       | `EventType` | Mirrors `events.Event.Type` (see `DESIGN.md` §8.1) |
+| `Seq`        | `uint64`    | Monotonic per (task, session, request); mirrors `events.Event.Seq` |
+| `OccurredAt` | `time.Time` |       |
+| `Payload`    | `[]byte`    | JSON serialization of the typed payload (see `events/PLAN.md`) |
+| `Schema`     | `string`    | Schema version label (`v1`) for forward compat |
+```
+
+- [ ] **Step 2: Adjust the TranscriptRecord description**
+
+Same file, the `TranscriptRecord` section references DESIGN.md §9. The DESIGN doc lists `Seq` as `int` — update DESIGN.md too:
+
+In `pkg/orchestrator/DESIGN.md` §9 transcript table (around line 760-770), change the `Seq` row's Type column from `int` to `uint64`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pkg/orchestrator/audit/PLAN.md pkg/orchestrator/DESIGN.md
+git commit -m "docs(audit): record Seq field in PLAN and DESIGN transcript tables"
+```
+
+---
+
+## Task 4: Declare `ErrNoSink` in audit/PLAN.md public surface
+
+**Files:**
+- Modify: `pkg/orchestrator/audit/PLAN.md:29`
+
+- [ ] **Step 1: Add ErrNoSink to the sentinel list**
+
+In `pkg/orchestrator/audit/PLAN.md`, find the line:
+
+```markdown
+- Sentinels: `ErrSinkClosed`, `ErrSinkBackpressure`.
+```
+
+Replace with:
+
+```markdown
+- Sentinels: `ErrSinkClosed`, `ErrSinkBackpressure`, `ErrNoSink` (returned by `Multi(...)` write paths when constructed with zero non-nil sinks), `ErrRedactionStructure` (returned by `ApplyRedaction` when the policy drops structural metadata).
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add pkg/orchestrator/audit/PLAN.md
+git commit -m "docs(audit): declare ErrNoSink and ErrRedactionStructure in PLAN public surface"
+```
+
+---
+
+## Task 5: Declare `Subscription.Dropped()` in events/PLAN.md public surface
+
+**Files:**
+- Modify: `pkg/orchestrator/events/PLAN.md:17-20`
+
+- [ ] **Step 1: Add Dropped() method to the Subscription interface listing**
+
+In `pkg/orchestrator/events/PLAN.md`, replace the Subscription block:
+
+```markdown
+- `Subscription` interface:
+  - `Events() <-chan Event`
+  - `Errors() <-chan error` — surface non-fatal subscriber issues
+  - `Dropped() uint64` — cumulative count of events dropped for this subscriber
+  - `Close() error`
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add pkg/orchestrator/events/PLAN.md
+git commit -m "docs(events): declare Subscription.Dropped() in PLAN public surface"
+```
+
+---
+
+## Task 6: Align events/PLAN.md drop-policy and `Publish` semantics with the implementation
+
+**Files:**
+- Modify: `pkg/orchestrator/events/PLAN.md:66-72` (Drop policy)
+- Modify: `pkg/orchestrator/events/PLAN.md:87-89` (Edge cases — empty TaskID)
+
+Background: PLAN says drops are flushed "periodically (e.g., every 1 second per subscriber)" but the implementation pushes a `SubscriberLaggedError` inline on every drop, coalescing to the latest count when `Errors()` is full. PLAN also says `Publish` with empty TaskID "rejects" — implementation silently returns `(0, 0)` because the interface has no error return.
+
+- [ ] **Step 1: Rewrite the Drop policy section**
+
+Replace lines 66-72 of `pkg/orchestrator/events/PLAN.md`:
+
+```markdown
+## Drop policy
+
+- v1 uses pure non-blocking buffered channels per subscriber. No coalescing
+  of chunk events.
+- A drop produces a `SubscriberLaggedError` pushed inline onto the
+  subscriber's `Errors()` channel. When that channel (buffer size 1) is
+  full, the bus drops the older notification and replaces it with the
+  newer one — consumers always see the latest cumulative `Dropped()`
+  count, never a stale one. They may miss intermediate counts.
+- The bus does not implement backoff or rate limiting in v1.
+```
+
+- [ ] **Step 2: Soften the empty-TaskID rejection language**
+
+Replace lines 87-89 of the same file:
+
+```markdown
+- Publishing with `task_id == ""`: the bus ignores the publish (zero
+  delivered, zero dropped). The `Bus.Publish` signature has no error
+  return because publishers are best-effort; callers MUST validate
+  `task_id` before invoking. Same for an already-cancelled `ctx`.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pkg/orchestrator/events/PLAN.md
+git commit -m "docs(events): align PLAN drop policy and Publish semantics with implementation"
+```
+
+---
+
+## Task 7: Add cross-package sync comment to `EventType` constants
+
+**Files:**
+- Modify: `pkg/orchestrator/audit/audit.go:25-44`
+- Modify: `pkg/orchestrator/events/events.go:21-40`
+
+Background: The two packages cannot import each other (per AGENTS.md), so the `EventType` constants are duplicated. Both blocks need a one-line comment marker reminding maintainers to keep them in sync.
+
+- [ ] **Step 1: Add the sync comment in audit.go**
+
+In `pkg/orchestrator/audit/audit.go`, replace the `EventType` declaration with:
+
+```go
+// EventType enumerates the audit event taxonomy. The values MUST stay in
+// lockstep with events.EventType in pkg/orchestrator/events/events.go —
+// AGENTS.md forbids cross-imports between audit and events, so updates here
+// require a matching edit in events.go.
+type EventType string
+
+const (
+    EventTypeTaskCreated      EventType = "task.created"
+    EventTypeTaskRunning      EventType = "task.running"
+    EventTypeTaskCompleted    EventType = "task.completed"
+    EventTypeTaskFailed       EventType = "task.failed"
+    EventTypeTaskCancelled    EventType = "task.cancelled"
+    EventTypeSessionOpened    EventType = "session.opened"
+    EventTypeSessionPaused    EventType = "session.paused"
+    EventTypeSessionResumed   EventType = "session.resumed"
+    EventTypeSessionClosed    EventType = "session.closed"
+    EventTypeSessionFailed    EventType = "session.failed"
+    EventTypeRequestCreated   EventType = "request.created"
+    EventTypeRequestRunning   EventType = "request.running"
+    EventTypeRequestCompleted EventType = "request.completed"
+    EventTypeRequestFailed    EventType = "request.failed"
+    EventTypeRequestTextChunk EventType = "request.text_chunk"
+    EventTypeRouteDirective   EventType = "route.directive"
+)
+```
+
+- [ ] **Step 2: Add the matching sync comment in events.go**
+
+In `pkg/orchestrator/events/events.go`, replace the `EventType` declaration with:
+
+```go
+// EventType enumerates the runtime bus event taxonomy. The values MUST stay
+// in lockstep with audit.EventType in pkg/orchestrator/audit/audit.go —
+// AGENTS.md forbids cross-imports between events and audit, so updates here
+// require a matching edit in audit.go.
+type EventType string
+
+const (
+    EventTypeTaskCreated      EventType = "task.created"
+    EventTypeTaskRunning      EventType = "task.running"
+    EventTypeTaskCompleted    EventType = "task.completed"
+    EventTypeTaskFailed       EventType = "task.failed"
+    EventTypeTaskCancelled    EventType = "task.cancelled"
+    EventTypeSessionOpened    EventType = "session.opened"
+    EventTypeSessionPaused    EventType = "session.paused"
+    EventTypeSessionResumed   EventType = "session.resumed"
+    EventTypeSessionClosed    EventType = "session.closed"
+    EventTypeSessionFailed    EventType = "session.failed"
+    EventTypeRequestCreated   EventType = "request.created"
+    EventTypeRequestRunning   EventType = "request.running"
+    EventTypeRequestCompleted EventType = "request.completed"
+    EventTypeRequestFailed    EventType = "request.failed"
+    EventTypeRequestTextChunk EventType = "request.text_chunk"
+    EventTypeRouteDirective   EventType = "route.directive"
+)
+```
+
+- [ ] **Step 3: Run vet to confirm no formatting drift**
+
+Run: `gofmt -s -d pkg/orchestrator/audit/audit.go pkg/orchestrator/events/events.go && go vet ./pkg/orchestrator/...`
+Expected: zero output from `gofmt -d`; vet clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pkg/orchestrator/audit/audit.go pkg/orchestrator/events/events.go
+git commit -m "docs(audit,events): annotate cross-package EventType duplication"
+```
+
+---
+
+## Task 8: Fix `multiSink.Close` to return nil when no sinks are configured
+
+**Files:**
+- Modify: `pkg/orchestrator/audit/audit.go:320-330`
+- Modify: `pkg/orchestrator/audit/audit_test.go` (new test)
+
+Background: `WriteEvent` / `WriteTranscript` returning `ErrNoSink` on empty sinks is correct — silently dropping audit data would be unsafe. `Close` has no data-loss risk; closing a sink with nothing to close should succeed.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `pkg/orchestrator/audit/audit_test.go`:
+
+```go
+func TestMulti_CloseWithNoSinksIsNoop(t *testing.T) {
+    ctx := context.Background()
+    sink := Multi(nil)
+
+    if err := sink.Close(ctx); err != nil {
+        t.Fatalf("Close() error = %v, want nil for empty Multi", err)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./pkg/orchestrator/audit -run TestMulti_CloseWithNoSinksIsNoop -v`
+Expected: FAIL with `Close() error = close audit multi sink: audit sink missing, want nil for empty Multi`.
+
+- [ ] **Step 3: Fix `multiSink.Close`**
+
+In `pkg/orchestrator/audit/audit.go`, replace lines 320-330:
+
+```go
+func (s multiSink) Close(ctx context.Context) error {
+    for i, sink := range s.sinks {
+        if err := sink.Close(ctx); err != nil {
+            return fmt.Errorf("close audit sink %d: %w", i, err)
+        }
+    }
+    return nil
+}
+```
+
+(Removed the `len(s.sinks) == 0` early-error path; the empty range is a clean no-op.)
+
+- [ ] **Step 4: Run the new test to verify it passes**
+
+Run: `go test ./pkg/orchestrator/audit -run TestMulti_CloseWithNoSinksIsNoop -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run full audit tests to confirm no regression**
+
+Run: `go test ./pkg/orchestrator/audit/... -race`
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pkg/orchestrator/audit/audit.go pkg/orchestrator/audit/audit_test.go
+git commit -m "fix(audit): multiSink.Close is a no-op when no sinks are configured"
+```
+
+---
+
+## Task 9: Replace tautological `TestFailingSinkReturnsErrorToCaller` with a real Multi fail-fast test
+
+**Files:**
+- Modify: `pkg/orchestrator/audit/audit_test.go:88-108`
+
+Background: The current test calls `stubSink.WriteTranscript` directly and asserts the stub returns the error it was configured with. It does not exercise any package code. The intended coverage — Multi propagating the first failing sink's error — is missing.
+
+- [ ] **Step 1: Extend `stubSink` with a transcript call counter**
+
+The existing stub only tracks `writeEventCalls`. The new test needs the transcript counterpart so it can assert short-circuiting precisely. In `pkg/orchestrator/audit/audit_test.go`, replace the `stubSink` block (lines 419-437):
+
+```go
+type stubSink struct {
+    writeEventErr        error
+    writeTranscriptErr   error
+    closeErr             error
+    writeEventCalls      int
+    writeTranscriptCalls int
+}
+
+func (s *stubSink) WriteEvent(ctx context.Context, record EventRecord) error {
+    s.writeEventCalls++
+    return s.writeEventErr
+}
+
+func (s *stubSink) WriteTranscript(ctx context.Context, record TranscriptRecord) error {
+    s.writeTranscriptCalls++
+    return s.writeTranscriptErr
+}
+
+func (s *stubSink) Close(ctx context.Context) error {
+    return s.closeErr
+}
+```
+
+- [ ] **Step 2: Replace the tautological test with a real Multi pipeline assertion**
+
+In the same file, delete the entire `TestFailingSinkReturnsErrorToCaller` function (lines 88-108) and add in its place:
+
+```go
+func TestMulti_PropagatesFirstFailingTranscriptError(t *testing.T) {
+    ctx := context.Background()
+    wantErr := errors.New("disk full")
+    first := NewMemorySink()
+    failing := &stubSink{writeTranscriptErr: wantErr}
+    third := &stubSink{}
+    sink := Multi(first, failing, third)
+
+    record := TranscriptRecord{
+        TaskID:      "task-1",
+        SessionID:   "session-1",
+        RequestID:   "request-1",
+        Kind:        TranscriptKindOutput,
+        Content:     []byte("output"),
+        ContentType: "text/plain",
+        Seq:         1,
+        Schema:      SchemaV1,
+        CreatedAt:   time.Now(),
+    }
+
+    err := sink.WriteTranscript(ctx, record)
+    if !errors.Is(err, wantErr) {
+        t.Fatalf("WriteTranscript() error = %v, want wrapping %v", err, wantErr)
+    }
+    if got := first.Transcripts("task-1"); len(got) != 1 {
+        t.Fatalf("first sink transcripts len = %d, want 1 (written before failure)", len(got))
+    }
+    if third.writeTranscriptCalls != 0 {
+        t.Fatalf("third sink writeTranscriptCalls = %d, want 0 (Multi must short-circuit on failure)", third.writeTranscriptCalls)
+    }
+}
+```
+
+- [ ] **Step 3: Run the new test**
+
+Run: `go test ./pkg/orchestrator/audit -run TestMulti_PropagatesFirstFailingTranscriptError -v`
+Expected: PASS.
+
+- [ ] **Step 4: Run full audit tests**
+
+Run: `go test ./pkg/orchestrator/audit/... -race`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/orchestrator/audit/audit_test.go
+git commit -m "test(audit): exercise Multi fail-fast through real pipeline, not stub directly"
+```
+
+---
+
+## Task 10: Add audit transcript ordering test
+
+**Files:**
+- Modify: `pkg/orchestrator/audit/audit_test.go` (new test)
+
+Background: `audit/PLAN.md` test 1 says "write events + transcripts, accessors return them in insertion order per task." The current `TestMemorySink_PreservesPerTaskOrder` only writes events.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `pkg/orchestrator/audit/audit_test.go`:
+
+```go
+func TestMemorySink_PreservesTranscriptInsertionOrder(t *testing.T) {
+    ctx := context.Background()
+    sink := NewMemorySink()
+    taskID := idgen.TaskID("task-ordering")
+
+    transcripts := []TranscriptRecord{
+        NewOutputTranscript(taskID, "session-1", "request-1", "first", 1, time.Unix(0, 1)),
+        NewOutputTranscript(taskID, "session-1", "request-1", "second", 2, time.Unix(0, 2)),
+        NewOutputTranscript(taskID, "session-1", "request-2", "third", 1, time.Unix(0, 3)),
+    }
+    for _, record := range transcripts {
+        if err := sink.WriteTranscript(ctx, record); err != nil {
+            t.Fatalf("WriteTranscript() error = %v", err)
+        }
+    }
+
+    got := sink.Transcripts(taskID)
+    if len(got) != len(transcripts) {
+        t.Fatalf("Transcripts() len = %d, want %d", len(got), len(transcripts))
+    }
+    wantContent := []string{"first", "second", "third"}
+    for i, expected := range wantContent {
+        if string(got[i].Content) != expected {
+            t.Fatalf("Transcripts()[%d].Content = %q, want %q", i, got[i].Content, expected)
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `go test ./pkg/orchestrator/audit -run TestMemorySink_PreservesTranscriptInsertionOrder -v`
+Expected: PASS (the implementation already preserves order; this just locks it in).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pkg/orchestrator/audit/audit_test.go
+git commit -m "test(audit): assert MemorySink transcript insertion order per task"
+```
+
+---
+
+## Task 11: Add events multi-event ordering test
+
+**Files:**
+- Modify: `pkg/orchestrator/events/events_test.go` (new test)
+
+Background: `events/PLAN.md` test 1 says "Subscribe → Publish → Events delivered in order." The current single-event test cannot verify ordering.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `pkg/orchestrator/events/events_test.go`, after `TestBus_SubscriberReceivesPublishedEvent`:
+
+```go
+func TestBus_DeliversEventsInPublishOrder(t *testing.T) {
+    ctx := context.Background()
+    bus := NewBus()
+    sub, err := bus.Subscribe(ctx, SubscribeOptions{TaskID: "task-1", BufferSize: 8, IncludeChunks: true})
+    if err != nil {
+        t.Fatalf("Subscribe() error = %v", err)
+    }
+    defer sub.Close()
+
+    sequence := []EventType{
+        EventTypeTaskCreated,
+        EventTypeTaskRunning,
+        EventTypeSessionOpened,
+        EventTypeRequestCreated,
+        EventTypeRequestRunning,
+        EventTypeRequestTextChunk,
+        EventTypeRequestCompleted,
+        EventTypeSessionClosed,
+    }
+    for i, typ := range sequence {
+        delivered, dropped := bus.Publish(ctx, testBusEvent("task-1", "session-1", "request-1", typ, uint64(i+1)))
+        if delivered != 1 || dropped != 0 {
+            t.Fatalf("Publish(%q) delivered/dropped = %d/%d, want 1/0", typ, delivered, dropped)
+        }
+    }
+
+    for i, want := range sequence {
+        got := receiveEvent(t, sub.Events())
+        if got.Type != want {
+            t.Fatalf("event[%d].Type = %q, want %q", i, got.Type, want)
+        }
+        if got.Seq != uint64(i+1) {
+            t.Fatalf("event[%d].Seq = %d, want %d", i, got.Seq, i+1)
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `go test ./pkg/orchestrator/events -run TestBus_DeliversEventsInPublishOrder -v`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pkg/orchestrator/events/events_test.go
+git commit -m "test(events): assert publish-order delivery for multi-event subscriptions"
+```
+
+---
+
+## Task 12: Harden `TestBus_ConcurrentPublishSubscribe` against the tight-buffer hang
+
+**Files:**
+- Modify: `pkg/orchestrator/events/events_test.go:248-292`
+
+Background: `BufferSize = publishers * perPublisher` (= total events). If any event is dropped, the drain loop blocks on `receiveEvent` and hits its 1-second timeout — instead of asserting `Dropped() == 0` and producing a useful failure message. Two cheap fixes: (a) double the buffer so a sporadic stall can't fill it, (b) check `Dropped()` before the drain loop.
+
+- [ ] **Step 1: Rewrite the test to check drops first**
+
+In `pkg/orchestrator/events/events_test.go`, replace the body of `TestBus_ConcurrentPublishSubscribe` (lines 248-292):
+
+```go
+func TestBus_ConcurrentPublishSubscribe(t *testing.T) {
+    ctx := context.Background()
+    bus := NewBus()
+    const subscribers = 8
+    const publishers = 8
+    const perPublisher = 25
+    const totalEvents = publishers * perPublisher
+
+    subs := make([]Subscription, 0, subscribers)
+    for range subscribers {
+        sub, err := bus.Subscribe(ctx, SubscribeOptions{
+            TaskID:        "task-1",
+            BufferSize:    totalEvents * 2, // headroom so a transient stall cannot cause drops
+            IncludeChunks: true,
+        })
+        if err != nil {
+            t.Fatalf("Subscribe() error = %v", err)
+        }
+        subs = append(subs, sub)
+    }
+    defer func() {
+        for _, sub := range subs {
+            if err := sub.Close(); err != nil {
+                t.Errorf("Close() error = %v", err)
+            }
+        }
+    }()
+
+    var wg sync.WaitGroup
+    for publisher := range publishers {
+        wg.Add(1)
+        go func(publisher int) {
+            defer wg.Done()
+            for seq := range perPublisher {
+                event := testBusEvent("task-1", "session-1", "request-1", EventTypeRequestTextChunk, uint64(publisher*perPublisher+seq))
+                bus.Publish(ctx, event)
+            }
+        }(publisher)
+    }
+    wg.Wait()
+
+    // Check drop counters BEFORE draining, so an unexpected drop is reported
+    // as a clean assertion failure instead of hanging on the drain loop.
+    for i, sub := range subs {
+        if dropped := sub.Dropped(); dropped != 0 {
+            t.Fatalf("sub %d Dropped() = %d before drain, want 0", i, dropped)
+        }
+    }
+
+    for i, sub := range subs {
+        for range totalEvents {
+            receiveEvent(t, sub.Events())
+        }
+        if dropped := sub.Dropped(); dropped != 0 {
+            t.Fatalf("sub %d Dropped() = %d after drain, want 0", i, dropped)
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the test under race detector**
+
+Run: `go test ./pkg/orchestrator/events -run TestBus_ConcurrentPublishSubscribe -race -v`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pkg/orchestrator/events/events_test.go
+git commit -m "test(events): harden ConcurrentPublishSubscribe against tight-buffer hangs"
+```
+
+---
+
+## Task 13: Final verification
+
+**Files:** (no edits — just gates)
+
+- [ ] **Step 1: Format check**
+
+Run: `gofmt -s -l pkg/orchestrator/audit pkg/orchestrator/events`
+Expected: empty output (no unformatted files).
+
+- [ ] **Step 2: Vet check**
+
+Run: `go vet ./pkg/orchestrator/audit/... ./pkg/orchestrator/events/...`
+Expected: clean.
+
+- [ ] **Step 3: Full test pass with race detector**
+
+Run: `go test ./pkg/orchestrator/audit/... ./pkg/orchestrator/events/... -race`
+Expected: all PASS, no `DATA RACE` warnings.
+
+- [ ] **Step 4: Confirm DESIGN / PLAN coherence**
+
+Run: `grep -n "Seq" pkg/orchestrator/DESIGN.md pkg/orchestrator/audit/PLAN.md pkg/orchestrator/events/PLAN.md`
+Expected: `Seq` appears in DESIGN §8.2 Event struct and in audit/PLAN.md EventRecord table; no stray `int` typing for `Seq`.
+
+Run: `grep -nE "ErrNoSink|Dropped\(\)" pkg/orchestrator/audit/PLAN.md pkg/orchestrator/events/PLAN.md`
+Expected: at least one match per term.
+
+- [ ] **Step 5: Build the whole tree**
+
+Run: `go build ./...`
+Expected: clean build.
+
+---
+
+## Out of Scope
+
+These were considered during review and explicitly deferred:
+
+- **`events.Publish` not signalling empty-TaskID / cancelled-ctx ignores via logs.** Adding a `logs.FromContext(ctx).Warn(...)` would require pulling the `pkg/logs` dependency into a leaf package that today has zero non-stdlib non-idgen imports. The doc-only fix in Task 6 ("callers MUST validate task_id") is the minimum acceptable resolution. A follow-up can add logging when the engine wires the bus up and there's a natural caller-side audit hook.
+- **Replacing the inline drop notification with a periodic ticker.** PLAN.md L69-70 originally promised "periodically (e.g., every 1 second per subscriber)" but the inline approach is cheaper (no extra goroutine per subscriber) and the latest-cumulative-count semantic preserves the user-visible guarantee. Task 6 aligns the doc to the code.
+- **Cleaning up `cloneReflectValue` for typed-map edge cases.** The redaction round-trip already has the `TestRedactionPolicy_InPlaceMutationCannotCorruptStructuralMetadata` test covering nested `map[string][]string` and `[]map[string]any`. Further hardening (e.g., custom JSON round-trip cloning) would be a bigger refactor with no observed bug today.

--- a/pkg/orchestrator/DESIGN.md
+++ b/pkg/orchestrator/DESIGN.md
@@ -727,6 +727,7 @@ type Event struct {
     SessionID  SessionID  // empty when type == task.*
     RequestID  RequestID  // empty when type == task.* / session.*
     Type       EventType
+    Seq        uint64     // monotonic per (task, session, request); audit and bus use the same width
     OccurredAt time.Time
     Payload    EventPayload // typed per Type
 }
@@ -765,7 +766,7 @@ post-Salutation or stripped user payload.
 | `Kind`          | `TranscriptKind` | input / output / event_summary |
 | `Content`       | `[]byte`         | JSON for `input` and `event_summary`; UTF-8 text for `output` |
 | `ContentType`   | `string`         | `text/plain` / `application/json` |
-| `Seq`           | `int`            | Monotonic per (task, session, request) |
+| `Seq`           | `uint64`         | Monotonic per (task, session, request) |
 | `Schema`        | `string`         | Schema version label for forward compat (`v1`) |
 | `CreatedAt`     | `time.Time`      |       |
 

--- a/pkg/orchestrator/audit/PLAN.md
+++ b/pkg/orchestrator/audit/PLAN.md
@@ -26,7 +26,7 @@ helpers (encoders, dedup keys) so external sinks can plug in.
   sinks. Aborts on the first error to keep semantics fail-fast.
 - `MemorySink` — reference in-memory implementation for tests, exposing
   `Events()` and `Transcripts()` accessors.
-- Sentinels: `ErrSinkClosed`, `ErrSinkBackpressure`.
+- Sentinels: `ErrSinkClosed`, `ErrSinkBackpressure`, `ErrNoSink` (returned by `Multi(...)` write paths when constructed with zero non-nil sinks), `ErrRedactionStructure` (returned by `ApplyRedaction` when the policy drops structural metadata).
 
 ## Contract
 
@@ -74,6 +74,7 @@ helpers (encoders, dedup keys) so external sinks can plug in.
 | `SessionID`  | `SessionID` | Empty for `task.*` events |
 | `RequestID`  | `RequestID` | Empty for `task.*` and `session.*` events |
 | `Type`       | `EventType` | Mirrors `events.Event.Type` (see `DESIGN.md` §8.1) |
+| `Seq`        | `uint64`    | Monotonic per (task, session, request); mirrors `events.Event.Seq` |
 | `OccurredAt` | `time.Time` |       |
 | `Payload`    | `[]byte`    | JSON serialization of the typed payload (see `events/PLAN.md`) |
 | `Schema`     | `string`    | Schema version label (`v1`) for forward compat |
@@ -138,14 +139,16 @@ The `event_summary` JSON has a stable shape:
   reads back from the audit sink (it is write-only from this side), so
   consumers own backward-compat policy.
 
-## Tests to write (no implementation in this pass)
+## Tests
 
 1. `MemorySink` happy path: write events + transcripts, accessors return
    them in insertion order per task.
 2. `Multi` aborts on first underlying failure, downstream sinks not
    contacted past the failed one.
-3. Concurrent writers under `-race` for `MemorySink`.
-4. Closed sink rejects writes with `ErrSinkClosed`.
+3. Transcript input records preserve the fully rendered request shape.
+4. Redaction policy preserves structural metadata.
+5. Concurrent writers under `-race` for `MemorySink`.
+6. Closed sink rejects writes with `ErrSinkClosed`.
 
 ## Out of scope
 

--- a/pkg/orchestrator/audit/audit.go
+++ b/pkg/orchestrator/audit/audit.go
@@ -1,0 +1,472 @@
+// Package audit defines the orchestrator's synchronous, fail-fast audit sink.
+package audit
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"sync"
+	"time"
+
+	"github.com/AiRanthem/ANA/pkg/orchestrator/idgen"
+)
+
+const SchemaV1 = "v1"
+
+var (
+	ErrSinkClosed         = errors.New("audit sink closed")
+	ErrSinkBackpressure   = errors.New("audit sink backpressure")
+	ErrNoSink             = errors.New("audit sink missing")
+	ErrRedactionStructure = errors.New("audit redaction removed structural metadata")
+)
+
+// EventType enumerates the audit event taxonomy. The values MUST stay in
+// lockstep with events.EventType in pkg/orchestrator/events/events.go —
+// AGENTS.md forbids cross-imports between audit and events, so updates here
+// require a matching edit in events.go.
+type EventType string
+
+const (
+	EventTypeTaskCreated      EventType = "task.created"
+	EventTypeTaskRunning      EventType = "task.running"
+	EventTypeTaskCompleted    EventType = "task.completed"
+	EventTypeTaskFailed       EventType = "task.failed"
+	EventTypeTaskCancelled    EventType = "task.cancelled"
+	EventTypeSessionOpened    EventType = "session.opened"
+	EventTypeSessionPaused    EventType = "session.paused"
+	EventTypeSessionResumed   EventType = "session.resumed"
+	EventTypeSessionClosed    EventType = "session.closed"
+	EventTypeSessionFailed    EventType = "session.failed"
+	EventTypeRequestCreated   EventType = "request.created"
+	EventTypeRequestRunning   EventType = "request.running"
+	EventTypeRequestCompleted EventType = "request.completed"
+	EventTypeRequestFailed    EventType = "request.failed"
+	EventTypeRequestTextChunk EventType = "request.text_chunk"
+	EventTypeRouteDirective   EventType = "route.directive"
+)
+
+type TranscriptKind string
+
+const (
+	TranscriptKindInput        TranscriptKind = "input"
+	TranscriptKindOutput       TranscriptKind = "output"
+	TranscriptKindEventSummary TranscriptKind = "event_summary"
+)
+
+// Sink is the durable audit boundary. Write calls are synchronous: a nil error
+// means the sink accepted responsibility for the record.
+type Sink interface {
+	WriteEvent(ctx context.Context, record EventRecord) error
+	WriteTranscript(ctx context.Context, record TranscriptRecord) error
+	Close(ctx context.Context) error
+}
+
+type EventRecord struct {
+	EventID    string
+	TaskID     idgen.TaskID
+	SessionID  idgen.SessionID
+	RequestID  idgen.RequestID
+	Type       EventType
+	Seq        uint64
+	OccurredAt time.Time
+	Payload    []byte
+	Schema     string
+}
+
+type TranscriptRecord struct {
+	TaskID      idgen.TaskID
+	SessionID   idgen.SessionID
+	RequestID   idgen.RequestID
+	Kind        TranscriptKind
+	Content     []byte
+	ContentType string
+	Seq         uint64
+	Schema      string
+	CreatedAt   time.Time
+}
+
+type FullyRenderedRequest struct {
+	TaskID            idgen.TaskID         `json:"task_id"`
+	SessionID         idgen.SessionID      `json:"session_id"`
+	RequestID         idgen.RequestID      `json:"request_id"`
+	WorkspaceID       string               `json:"workspace_id"`
+	WorkspaceAlias    string               `json:"workspace_alias"`
+	AgentKey          string               `json:"agent_key"`
+	RuntimeType       string               `json:"runtime_type"`
+	RuntimeKind       string               `json:"runtime_kind"`
+	Inputs            []RenderedInputPart  `json:"inputs"`
+	Attachments       []AttachmentMetadata `json:"attachments,omitempty"`
+	PromptDiagnostics map[string]any       `json:"prompt_diagnostics,omitempty"`
+	RegistrySnapshot  json.RawMessage      `json:"registry_snapshot,omitempty"`
+	RegistryReference string               `json:"registry_reference,omitempty"`
+	TemplateVersion   string               `json:"template_version,omitempty"`
+	Metadata          map[string]string    `json:"metadata,omitempty"`
+}
+
+type RenderedInputPart struct {
+	Role             string            `json:"role"`
+	Kind             string            `json:"kind"`
+	Content          string            `json:"content,omitempty"`
+	ContentReference string            `json:"content_reference,omitempty"`
+	SizeBytes        int               `json:"size_bytes"`
+	SourceReference  string            `json:"source_reference,omitempty"`
+	Metadata         map[string]string `json:"metadata,omitempty"`
+	Redacted         bool              `json:"redacted,omitempty"`
+	RedactionTag     string            `json:"redaction_tag,omitempty"`
+}
+
+type AttachmentMetadata struct {
+	Kind         string            `json:"kind"`
+	Name         string            `json:"name,omitempty"`
+	Reference    string            `json:"reference,omitempty"`
+	SizeBytes    int64             `json:"size_bytes,omitempty"`
+	Digest       string            `json:"digest,omitempty"`
+	Metadata     map[string]string `json:"metadata,omitempty"`
+	Redacted     bool              `json:"redacted,omitempty"`
+	RedactionTag string            `json:"redaction_tag,omitempty"`
+}
+
+type RedactionPolicy interface {
+	RedactRequest(FullyRenderedRequest) (FullyRenderedRequest, error)
+}
+
+type RedactionPolicyFunc func(FullyRenderedRequest) (FullyRenderedRequest, error)
+
+func (f RedactionPolicyFunc) RedactRequest(request FullyRenderedRequest) (FullyRenderedRequest, error) {
+	return f(request)
+}
+
+func ApplyRedaction(request FullyRenderedRequest, policy RedactionPolicy) (FullyRenderedRequest, error) {
+	if policy == nil {
+		return request, nil
+	}
+	original := cloneFullyRenderedRequest(request)
+	redacted, err := policy.RedactRequest(cloneFullyRenderedRequest(request))
+	if err != nil {
+		return FullyRenderedRequest{}, fmt.Errorf("redact audit request: %w", err)
+	}
+	restored, err := preserveRequiredMetadata(original, redacted)
+	if err != nil {
+		return FullyRenderedRequest{}, err
+	}
+	return restored, nil
+}
+
+func NewInputTranscript(request FullyRenderedRequest, seq uint64, createdAt time.Time) (TranscriptRecord, error) {
+	content, err := json.Marshal(request)
+	if err != nil {
+		return TranscriptRecord{}, fmt.Errorf("marshal input transcript: %w", err)
+	}
+	return TranscriptRecord{
+		TaskID:      request.TaskID,
+		SessionID:   request.SessionID,
+		RequestID:   request.RequestID,
+		Kind:        TranscriptKindInput,
+		Content:     content,
+		ContentType: "application/json",
+		Seq:         seq,
+		Schema:      SchemaV1,
+		CreatedAt:   createdAt,
+	}, nil
+}
+
+func NewOutputTranscript(taskID idgen.TaskID, sessionID idgen.SessionID, requestID idgen.RequestID, output string, seq uint64, createdAt time.Time) TranscriptRecord {
+	return TranscriptRecord{
+		TaskID:      taskID,
+		SessionID:   sessionID,
+		RequestID:   requestID,
+		Kind:        TranscriptKindOutput,
+		Content:     []byte(output),
+		ContentType: "text/plain; charset=utf-8",
+		Seq:         seq,
+		Schema:      SchemaV1,
+		CreatedAt:   createdAt,
+	}
+}
+
+func NewEventSummaryTranscript(taskID idgen.TaskID, sessionID idgen.SessionID, requestID idgen.RequestID, summary any, seq uint64, createdAt time.Time) (TranscriptRecord, error) {
+	content, err := json.Marshal(summary)
+	if err != nil {
+		return TranscriptRecord{}, fmt.Errorf("marshal event summary transcript: %w", err)
+	}
+	return TranscriptRecord{
+		TaskID:      taskID,
+		SessionID:   sessionID,
+		RequestID:   requestID,
+		Kind:        TranscriptKindEventSummary,
+		Content:     content,
+		ContentType: "application/json",
+		Seq:         seq,
+		Schema:      SchemaV1,
+		CreatedAt:   createdAt,
+	}, nil
+}
+
+type MemorySink struct {
+	mu          sync.Mutex
+	closed      bool
+	events      []EventRecord
+	transcripts []TranscriptRecord
+}
+
+func NewMemorySink() *MemorySink {
+	return &MemorySink{}
+}
+
+func (s *MemorySink) WriteEvent(ctx context.Context, record EventRecord) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("write audit event %q task %q: %w", record.EventID, record.TaskID, err)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return fmt.Errorf("write audit event %q task %q: %w", record.EventID, record.TaskID, ErrSinkClosed)
+	}
+	s.events = append(s.events, cloneEventRecord(record))
+	return nil
+}
+
+func (s *MemorySink) WriteTranscript(ctx context.Context, record TranscriptRecord) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("write audit transcript task %q session %q request %q kind %q seq %d: %w", record.TaskID, record.SessionID, record.RequestID, record.Kind, record.Seq, err)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return fmt.Errorf("write audit transcript task %q session %q request %q kind %q seq %d: %w", record.TaskID, record.SessionID, record.RequestID, record.Kind, record.Seq, ErrSinkClosed)
+	}
+	s.transcripts = append(s.transcripts, cloneTranscriptRecord(record))
+	return nil
+}
+
+func (s *MemorySink) Close(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("close audit memory sink: %w", err)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.closed = true
+	return nil
+}
+
+func (s *MemorySink) Events(taskID idgen.TaskID) []EventRecord {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	records := make([]EventRecord, 0, len(s.events))
+	for _, record := range s.events {
+		if record.TaskID == taskID {
+			records = append(records, cloneEventRecord(record))
+		}
+	}
+	return records
+}
+
+func (s *MemorySink) Transcripts(taskID idgen.TaskID) []TranscriptRecord {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	records := make([]TranscriptRecord, 0, len(s.transcripts))
+	for _, record := range s.transcripts {
+		if record.TaskID == taskID {
+			records = append(records, cloneTranscriptRecord(record))
+		}
+	}
+	return records
+}
+
+func (s *MemorySink) Reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = nil
+	s.transcripts = nil
+	s.closed = false
+}
+
+func Multi(sinks ...Sink) Sink {
+	filtered := make([]Sink, 0, len(sinks))
+	for _, sink := range sinks {
+		if sink != nil {
+			filtered = append(filtered, sink)
+		}
+	}
+	return multiSink{sinks: filtered}
+}
+
+type multiSink struct {
+	sinks []Sink
+}
+
+func (s multiSink) WriteEvent(ctx context.Context, record EventRecord) error {
+	if len(s.sinks) == 0 {
+		return fmt.Errorf("write audit event task %q event %q: %w", record.TaskID, record.EventID, ErrNoSink)
+	}
+	for i, sink := range s.sinks {
+		if err := sink.WriteEvent(ctx, record); err != nil {
+			return fmt.Errorf("write audit event sink %d task %q event %q: %w", i, record.TaskID, record.EventID, err)
+		}
+	}
+	return nil
+}
+
+func (s multiSink) WriteTranscript(ctx context.Context, record TranscriptRecord) error {
+	if len(s.sinks) == 0 {
+		return fmt.Errorf("write audit transcript task %q session %q request %q kind %q seq %d: %w", record.TaskID, record.SessionID, record.RequestID, record.Kind, record.Seq, ErrNoSink)
+	}
+	for i, sink := range s.sinks {
+		if err := sink.WriteTranscript(ctx, record); err != nil {
+			return fmt.Errorf("write audit transcript sink %d task %q session %q request %q kind %q seq %d: %w", i, record.TaskID, record.SessionID, record.RequestID, record.Kind, record.Seq, err)
+		}
+	}
+	return nil
+}
+
+func (s multiSink) Close(ctx context.Context) error {
+	for i, sink := range s.sinks {
+		if err := sink.Close(ctx); err != nil {
+			return fmt.Errorf("close audit sink %d: %w", i, err)
+		}
+	}
+	return nil
+}
+
+func preserveRequiredMetadata(original FullyRenderedRequest, redacted FullyRenderedRequest) (FullyRenderedRequest, error) {
+	if len(redacted.Inputs) != len(original.Inputs) {
+		return FullyRenderedRequest{}, fmt.Errorf("redact audit request inputs length %d want %d: %w", len(redacted.Inputs), len(original.Inputs), ErrRedactionStructure)
+	}
+	if len(redacted.Attachments) != len(original.Attachments) {
+		return FullyRenderedRequest{}, fmt.Errorf("redact audit request attachments length %d want %d: %w", len(redacted.Attachments), len(original.Attachments), ErrRedactionStructure)
+	}
+	redacted.TaskID = original.TaskID
+	redacted.SessionID = original.SessionID
+	redacted.RequestID = original.RequestID
+	redacted.WorkspaceID = original.WorkspaceID
+	redacted.WorkspaceAlias = original.WorkspaceAlias
+	redacted.AgentKey = original.AgentKey
+	redacted.RuntimeType = original.RuntimeType
+	redacted.RuntimeKind = original.RuntimeKind
+	redacted.PromptDiagnostics = cloneAnyMap(redacted.PromptDiagnostics)
+	redacted.RegistrySnapshot = append(json.RawMessage(nil), redacted.RegistrySnapshot...)
+	redacted.RegistryReference = original.RegistryReference
+	redacted.TemplateVersion = original.TemplateVersion
+	redacted.Metadata = cloneStringMap(redacted.Metadata)
+	for i := range redacted.Inputs {
+		redacted.Inputs[i].Role = original.Inputs[i].Role
+		redacted.Inputs[i].Kind = original.Inputs[i].Kind
+		redacted.Inputs[i].SizeBytes = original.Inputs[i].SizeBytes
+		redacted.Inputs[i].SourceReference = original.Inputs[i].SourceReference
+		redacted.Inputs[i].ContentReference = original.Inputs[i].ContentReference
+		redacted.Inputs[i].Metadata = cloneStringMap(original.Inputs[i].Metadata)
+	}
+	for i := range redacted.Attachments {
+		redacted.Attachments[i].Kind = original.Attachments[i].Kind
+		redacted.Attachments[i].Reference = original.Attachments[i].Reference
+		redacted.Attachments[i].SizeBytes = original.Attachments[i].SizeBytes
+		redacted.Attachments[i].Digest = original.Attachments[i].Digest
+		redacted.Attachments[i].Metadata = cloneStringMap(original.Attachments[i].Metadata)
+	}
+	return redacted, nil
+}
+
+func cloneFullyRenderedRequest(request FullyRenderedRequest) FullyRenderedRequest {
+	clone := request
+	clone.Inputs = make([]RenderedInputPart, len(request.Inputs))
+	for i, part := range request.Inputs {
+		clone.Inputs[i] = part
+		clone.Inputs[i].Metadata = cloneStringMap(part.Metadata)
+	}
+	clone.Attachments = make([]AttachmentMetadata, len(request.Attachments))
+	for i, attachment := range request.Attachments {
+		clone.Attachments[i] = attachment
+		clone.Attachments[i].Metadata = cloneStringMap(attachment.Metadata)
+	}
+	clone.PromptDiagnostics = cloneAnyMap(request.PromptDiagnostics)
+	clone.RegistrySnapshot = append(json.RawMessage(nil), request.RegistrySnapshot...)
+	clone.Metadata = cloneStringMap(request.Metadata)
+	return clone
+}
+
+func cloneStringMap(in map[string]string) map[string]string {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}
+
+func cloneAnyMap(in map[string]any) map[string]any {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for key, value := range in {
+		out[key] = cloneAnyValue(value)
+	}
+	return out
+}
+
+func cloneAnyValue(value any) any {
+	if value == nil {
+		return nil
+	}
+	return cloneReflectValue(reflect.ValueOf(value)).Interface()
+}
+
+func cloneReflectValue(value reflect.Value) reflect.Value {
+	if !value.IsValid() {
+		return value
+	}
+
+	switch value.Kind() {
+	case reflect.Interface:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		cloned := cloneReflectValue(value.Elem())
+		wrapped := reflect.New(value.Type()).Elem()
+		wrapped.Set(cloned)
+		return wrapped
+	case reflect.Map:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		cloned := reflect.MakeMapWithSize(value.Type(), value.Len())
+		iter := value.MapRange()
+		for iter.Next() {
+			cloned.SetMapIndex(cloneReflectValue(iter.Key()), cloneReflectValue(iter.Value()))
+		}
+		return cloned
+	case reflect.Slice:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		cloned := reflect.MakeSlice(value.Type(), value.Len(), value.Len())
+		for i := range value.Len() {
+			cloned.Index(i).Set(cloneReflectValue(value.Index(i)))
+		}
+		return cloned
+	case reflect.Array:
+		cloned := reflect.New(value.Type()).Elem()
+		for i := range value.Len() {
+			cloned.Index(i).Set(cloneReflectValue(value.Index(i)))
+		}
+		return cloned
+	default:
+		return value
+	}
+}
+
+func cloneEventRecord(record EventRecord) EventRecord {
+	clone := record
+	clone.Payload = append([]byte(nil), record.Payload...)
+	return clone
+}
+
+func cloneTranscriptRecord(record TranscriptRecord) TranscriptRecord {
+	clone := record
+	clone.Content = append([]byte(nil), record.Content...)
+	return clone
+}

--- a/pkg/orchestrator/audit/audit.go
+++ b/pkg/orchestrator/audit/audit.go
@@ -320,15 +320,17 @@ func Multi(sinks ...Sink) Sink {
 }
 
 type multiSink struct {
-	mu     sync.Mutex
-	closed bool
-	sinks  []Sink
+	mu          sync.Mutex
+	closing     bool
+	closed      bool
+	closedSinks []bool
+	sinks       []Sink
 }
 
 func (s *multiSink) WriteEvent(ctx context.Context, record EventRecord) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.closed {
+	if s.closing || s.closed {
 		return fmt.Errorf("write audit event task %q event %q: %w", record.TaskID, record.EventID, ErrSinkClosed)
 	}
 	if err := ctx.Err(); err != nil {
@@ -348,7 +350,7 @@ func (s *multiSink) WriteEvent(ctx context.Context, record EventRecord) error {
 func (s *multiSink) WriteTranscript(ctx context.Context, record TranscriptRecord) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.closed {
+	if s.closing || s.closed {
 		return fmt.Errorf("write audit transcript task %q session %q request %q kind %q seq %d: %w", record.TaskID, record.SessionID, record.RequestID, record.Kind, record.Seq, ErrSinkClosed)
 	}
 	if err := ctx.Err(); err != nil {
@@ -374,15 +376,27 @@ func (s *multiSink) Close(ctx context.Context) error {
 	if err := ctx.Err(); err != nil {
 		return fmt.Errorf("close audit multi sink: %w", err)
 	}
-	s.closed = true
+	s.closing = true
+	if s.closedSinks == nil {
+		s.closedSinks = make([]bool, len(s.sinks))
+	}
 
 	var errs []error
 	for i, sink := range s.sinks {
+		if s.closedSinks[i] {
+			continue
+		}
 		if err := sink.Close(ctx); err != nil {
 			errs = append(errs, fmt.Errorf("close audit sink %d: %w", i, err))
+			continue
 		}
+		s.closedSinks[i] = true
 	}
-	return errors.Join(errs...)
+	if err := errors.Join(errs...); err != nil {
+		return err
+	}
+	s.closed = true
+	return nil
 }
 
 func preserveRequiredMetadata(original FullyRenderedRequest, redacted FullyRenderedRequest) (FullyRenderedRequest, error) {

--- a/pkg/orchestrator/audit/audit.go
+++ b/pkg/orchestrator/audit/audit.go
@@ -2,10 +2,12 @@
 package audit
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"reflect"
 	"sync"
 	"time"
@@ -128,6 +130,22 @@ type AttachmentMetadata struct {
 	RedactionTag string            `json:"redaction_tag,omitempty"`
 }
 
+type UsageSummary struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
+// EventSummary is the stable JSON payload stored for request outcome summaries.
+type EventSummary struct {
+	Usage        UsageSummary `json:"usage"`
+	FinishReason string       `json:"finish_reason"`
+	ToolCalls    int          `json:"tool_calls"`
+	ToolResults  int          `json:"tool_results"`
+	Error        *string      `json:"error"`
+	DurationMS   int64        `json:"duration_ms"`
+}
+
 type RedactionPolicy interface {
 	RedactRequest(FullyRenderedRequest) (FullyRenderedRequest, error)
 }
@@ -139,11 +157,18 @@ func (f RedactionPolicyFunc) RedactRequest(request FullyRenderedRequest) (FullyR
 }
 
 func ApplyRedaction(request FullyRenderedRequest, policy RedactionPolicy) (FullyRenderedRequest, error) {
-	if policy == nil {
-		return request, nil
+	original, err := cloneFullyRenderedRequest(request)
+	if err != nil {
+		return FullyRenderedRequest{}, fmt.Errorf("redact audit request: %w", err)
 	}
-	original := cloneFullyRenderedRequest(request)
-	redacted, err := policy.RedactRequest(cloneFullyRenderedRequest(request))
+	if policy == nil {
+		return original, nil
+	}
+	policyInput, err := cloneFullyRenderedRequest(request)
+	if err != nil {
+		return FullyRenderedRequest{}, fmt.Errorf("redact audit request: %w", err)
+	}
+	redacted, err := policy.RedactRequest(policyInput)
 	if err != nil {
 		return FullyRenderedRequest{}, fmt.Errorf("redact audit request: %w", err)
 	}
@@ -186,7 +211,8 @@ func NewOutputTranscript(taskID idgen.TaskID, sessionID idgen.SessionID, request
 	}
 }
 
-func NewEventSummaryTranscript(taskID idgen.TaskID, sessionID idgen.SessionID, requestID idgen.RequestID, summary any, seq uint64, createdAt time.Time) (TranscriptRecord, error) {
+// NewEventSummaryTranscript marshals a request outcome summary into an audit transcript.
+func NewEventSummaryTranscript(taskID idgen.TaskID, sessionID idgen.SessionID, requestID idgen.RequestID, summary EventSummary, seq uint64, createdAt time.Time) (TranscriptRecord, error) {
 	content, err := json.Marshal(summary)
 	if err != nil {
 		return TranscriptRecord{}, fmt.Errorf("marshal event summary transcript: %w", err)
@@ -290,14 +316,24 @@ func Multi(sinks ...Sink) Sink {
 			filtered = append(filtered, sink)
 		}
 	}
-	return multiSink{sinks: filtered}
+	return &multiSink{sinks: filtered}
 }
 
 type multiSink struct {
-	sinks []Sink
+	mu     sync.Mutex
+	closed bool
+	sinks  []Sink
 }
 
-func (s multiSink) WriteEvent(ctx context.Context, record EventRecord) error {
+func (s *multiSink) WriteEvent(ctx context.Context, record EventRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return fmt.Errorf("write audit event task %q event %q: %w", record.TaskID, record.EventID, ErrSinkClosed)
+	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("write audit event task %q event %q: %w", record.TaskID, record.EventID, err)
+	}
 	if len(s.sinks) == 0 {
 		return fmt.Errorf("write audit event task %q event %q: %w", record.TaskID, record.EventID, ErrNoSink)
 	}
@@ -309,7 +345,15 @@ func (s multiSink) WriteEvent(ctx context.Context, record EventRecord) error {
 	return nil
 }
 
-func (s multiSink) WriteTranscript(ctx context.Context, record TranscriptRecord) error {
+func (s *multiSink) WriteTranscript(ctx context.Context, record TranscriptRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return fmt.Errorf("write audit transcript task %q session %q request %q kind %q seq %d: %w", record.TaskID, record.SessionID, record.RequestID, record.Kind, record.Seq, ErrSinkClosed)
+	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("write audit transcript task %q session %q request %q kind %q seq %d: %w", record.TaskID, record.SessionID, record.RequestID, record.Kind, record.Seq, err)
+	}
 	if len(s.sinks) == 0 {
 		return fmt.Errorf("write audit transcript task %q session %q request %q kind %q seq %d: %w", record.TaskID, record.SessionID, record.RequestID, record.Kind, record.Seq, ErrNoSink)
 	}
@@ -321,13 +365,24 @@ func (s multiSink) WriteTranscript(ctx context.Context, record TranscriptRecord)
 	return nil
 }
 
-func (s multiSink) Close(ctx context.Context) error {
+func (s *multiSink) Close(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("close audit multi sink: %w", err)
+	}
+	s.closed = true
+
+	var errs []error
 	for i, sink := range s.sinks {
 		if err := sink.Close(ctx); err != nil {
-			return fmt.Errorf("close audit sink %d: %w", i, err)
+			errs = append(errs, fmt.Errorf("close audit sink %d: %w", i, err))
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func preserveRequiredMetadata(original FullyRenderedRequest, redacted FullyRenderedRequest) (FullyRenderedRequest, error) {
@@ -345,10 +400,19 @@ func preserveRequiredMetadata(original FullyRenderedRequest, redacted FullyRende
 	redacted.AgentKey = original.AgentKey
 	redacted.RuntimeType = original.RuntimeType
 	redacted.RuntimeKind = original.RuntimeKind
-	redacted.PromptDiagnostics = cloneAnyMap(redacted.PromptDiagnostics)
+	promptDiagnostics, err := clonePromptDiagnostics(redacted.PromptDiagnostics)
+	if err != nil {
+		return FullyRenderedRequest{}, fmt.Errorf("redact audit request: %w", err)
+	}
+	redacted.PromptDiagnostics = promptDiagnostics
 	redacted.RegistrySnapshot = append(json.RawMessage(nil), redacted.RegistrySnapshot...)
-	redacted.RegistryReference = original.RegistryReference
-	redacted.TemplateVersion = original.TemplateVersion
+	if hasStableRegistryReference(original) {
+		if redacted.RegistryReference != original.RegistryReference || redacted.TemplateVersion != original.TemplateVersion {
+			return FullyRenderedRequest{}, fmt.Errorf("redact audit request changed stable registry reference/template from %q/%q to %q/%q: %w", original.RegistryReference, original.TemplateVersion, redacted.RegistryReference, redacted.TemplateVersion, ErrRedactionStructure)
+		}
+		redacted.RegistryReference = original.RegistryReference
+		redacted.TemplateVersion = original.TemplateVersion
+	}
 	redacted.Metadata = cloneStringMap(redacted.Metadata)
 	for i := range redacted.Inputs {
 		redacted.Inputs[i].Role = original.Inputs[i].Role
@@ -356,19 +420,62 @@ func preserveRequiredMetadata(original FullyRenderedRequest, redacted FullyRende
 		redacted.Inputs[i].SizeBytes = original.Inputs[i].SizeBytes
 		redacted.Inputs[i].SourceReference = original.Inputs[i].SourceReference
 		redacted.Inputs[i].ContentReference = original.Inputs[i].ContentReference
-		redacted.Inputs[i].Metadata = cloneStringMap(original.Inputs[i].Metadata)
+		redacted.Inputs[i].Metadata = cloneStringMap(redacted.Inputs[i].Metadata)
 	}
 	for i := range redacted.Attachments {
 		redacted.Attachments[i].Kind = original.Attachments[i].Kind
 		redacted.Attachments[i].Reference = original.Attachments[i].Reference
 		redacted.Attachments[i].SizeBytes = original.Attachments[i].SizeBytes
 		redacted.Attachments[i].Digest = original.Attachments[i].Digest
-		redacted.Attachments[i].Metadata = cloneStringMap(original.Attachments[i].Metadata)
+		redacted.Attachments[i].Metadata = cloneStringMap(redacted.Attachments[i].Metadata)
+	}
+	if err := validateRedactionStructure(original, redacted); err != nil {
+		return FullyRenderedRequest{}, err
 	}
 	return redacted, nil
 }
 
-func cloneFullyRenderedRequest(request FullyRenderedRequest) FullyRenderedRequest {
+func validateRedactionStructure(original FullyRenderedRequest, redacted FullyRenderedRequest) error {
+	for i, input := range redacted.Inputs {
+		if input.Content != original.Inputs[i].Content && !hasRedactionMarker(input.Redacted, input.RedactionTag) {
+			return fmt.Errorf("redact audit request input %d role %q kind %q changed content without redaction marker: %w", i, original.Inputs[i].Role, original.Inputs[i].Kind, ErrRedactionStructure)
+		}
+		if input.Content != "" || input.ContentReference != "" || hasRedactionMarker(input.Redacted, input.RedactionTag) {
+			continue
+		}
+		return fmt.Errorf("redact audit request input %d role %q kind %q removed content/reference/redaction marker: %w", i, original.Inputs[i].Role, original.Inputs[i].Kind, ErrRedactionStructure)
+	}
+	for i, attachment := range redacted.Attachments {
+		if attachment.Name != original.Attachments[i].Name && !hasRedactionMarker(attachment.Redacted, attachment.RedactionTag) {
+			return fmt.Errorf("redact audit request attachment %d kind %q changed name without redaction marker: %w", i, original.Attachments[i].Kind, ErrRedactionStructure)
+		}
+		if attachment.Name != "" || attachment.Reference != "" || attachment.Digest != "" || hasRedactionMarker(attachment.Redacted, attachment.RedactionTag) {
+			continue
+		}
+		return fmt.Errorf("redact audit request attachment %d kind %q removed name/reference/digest/redaction marker: %w", i, original.Attachments[i].Kind, ErrRedactionStructure)
+	}
+	if hasRegistryContext(original) && !hasRegistryContext(redacted) {
+		return fmt.Errorf("redact audit request removed registry snapshot/reference context: %w", ErrRedactionStructure)
+	}
+	if len(original.RegistrySnapshot) > 0 && !hasStableRegistryReference(redacted) && !bytes.Equal(redacted.RegistrySnapshot, original.RegistrySnapshot) {
+		return fmt.Errorf("redact audit request changed registry snapshot without stable registry reference: %w", ErrRedactionStructure)
+	}
+	return nil
+}
+
+func hasRedactionMarker(redacted bool, tag string) bool {
+	return redacted && tag != ""
+}
+
+func hasRegistryContext(request FullyRenderedRequest) bool {
+	return len(request.RegistrySnapshot) > 0 || (request.TemplateVersion != "" && request.RegistryReference != "")
+}
+
+func hasStableRegistryReference(request FullyRenderedRequest) bool {
+	return request.TemplateVersion != "" && request.RegistryReference != ""
+}
+
+func cloneFullyRenderedRequest(request FullyRenderedRequest) (FullyRenderedRequest, error) {
 	clone := request
 	clone.Inputs = make([]RenderedInputPart, len(request.Inputs))
 	for i, part := range request.Inputs {
@@ -380,10 +487,14 @@ func cloneFullyRenderedRequest(request FullyRenderedRequest) FullyRenderedReques
 		clone.Attachments[i] = attachment
 		clone.Attachments[i].Metadata = cloneStringMap(attachment.Metadata)
 	}
-	clone.PromptDiagnostics = cloneAnyMap(request.PromptDiagnostics)
+	promptDiagnostics, err := clonePromptDiagnostics(request.PromptDiagnostics)
+	if err != nil {
+		return FullyRenderedRequest{}, err
+	}
+	clone.PromptDiagnostics = promptDiagnostics
 	clone.RegistrySnapshot = append(json.RawMessage(nil), request.RegistrySnapshot...)
 	clone.Metadata = cloneStringMap(request.Metadata)
-	return clone
+	return clone, nil
 }
 
 func cloneStringMap(in map[string]string) map[string]string {
@@ -397,66 +508,135 @@ func cloneStringMap(in map[string]string) map[string]string {
 	return out
 }
 
-func cloneAnyMap(in map[string]any) map[string]any {
+func clonePromptDiagnostics(in map[string]any) (map[string]any, error) {
 	if in == nil {
-		return nil
+		return nil, nil
 	}
 	out := make(map[string]any, len(in))
 	for key, value := range in {
-		out[key] = cloneAnyValue(value)
+		cloned, err := clonePromptDiagnosticValue(value)
+		if err != nil {
+			return nil, fmt.Errorf("clone prompt diagnostics key %q: %w", key, err)
+		}
+		out[key] = cloned
 	}
-	return out
+	return out, nil
 }
 
-func cloneAnyValue(value any) any {
+func clonePromptDiagnosticValue(value any) (any, error) {
 	if value == nil {
-		return nil
+		return nil, nil
 	}
-	return cloneReflectValue(reflect.ValueOf(value)).Interface()
+	cloned, err := cloneJSONLikeValue(reflect.ValueOf(value), make(map[cloneVisit]struct{}))
+	if err != nil {
+		return nil, err
+	}
+	return cloned.Interface(), nil
 }
 
-func cloneReflectValue(value reflect.Value) reflect.Value {
+type cloneVisit struct {
+	typ reflect.Type
+	ptr uintptr
+}
+
+var jsonNumberType = reflect.TypeOf(json.Number(""))
+
+func cloneJSONLikeValue(value reflect.Value, active map[cloneVisit]struct{}) (reflect.Value, error) {
 	if !value.IsValid() {
-		return value
+		return value, nil
+	}
+	if value.Type() == jsonNumberType {
+		if err := validateJSONNumber(value.Interface().(json.Number)); err != nil {
+			return reflect.Value{}, err
+		}
+		return value, nil
 	}
 
 	switch value.Kind() {
 	case reflect.Interface:
 		if value.IsNil() {
-			return reflect.Zero(value.Type())
+			return reflect.Zero(value.Type()), nil
 		}
-		cloned := cloneReflectValue(value.Elem())
+		cloned, err := cloneJSONLikeValue(value.Elem(), active)
+		if err != nil {
+			return reflect.Value{}, err
+		}
 		wrapped := reflect.New(value.Type()).Elem()
 		wrapped.Set(cloned)
-		return wrapped
+		return wrapped, nil
 	case reflect.Map:
 		if value.IsNil() {
-			return reflect.Zero(value.Type())
+			return reflect.Zero(value.Type()), nil
 		}
+		if value.Type().Key().Kind() != reflect.String {
+			return reflect.Value{}, fmt.Errorf("unsupported prompt diagnostics map key type %s: %w", value.Type().Key(), ErrRedactionStructure)
+		}
+		visit := cloneVisit{typ: value.Type(), ptr: value.Pointer()}
+		if _, ok := active[visit]; ok {
+			return reflect.Value{}, fmt.Errorf("unsupported cyclic prompt diagnostics map %s: %w", value.Type(), ErrRedactionStructure)
+		}
+		active[visit] = struct{}{}
+		defer delete(active, visit)
+
 		cloned := reflect.MakeMapWithSize(value.Type(), value.Len())
 		iter := value.MapRange()
 		for iter.Next() {
-			cloned.SetMapIndex(cloneReflectValue(iter.Key()), cloneReflectValue(iter.Value()))
+			clonedValue, err := cloneJSONLikeValue(iter.Value(), active)
+			if err != nil {
+				return reflect.Value{}, err
+			}
+			cloned.SetMapIndex(iter.Key(), clonedValue)
 		}
-		return cloned
+		return cloned, nil
 	case reflect.Slice:
 		if value.IsNil() {
-			return reflect.Zero(value.Type())
+			return reflect.Zero(value.Type()), nil
+		}
+		visit := cloneVisit{typ: value.Type(), ptr: value.Pointer()}
+		if visit.ptr != 0 {
+			if _, ok := active[visit]; ok {
+				return reflect.Value{}, fmt.Errorf("unsupported cyclic prompt diagnostics slice %s: %w", value.Type(), ErrRedactionStructure)
+			}
+			active[visit] = struct{}{}
+			defer delete(active, visit)
 		}
 		cloned := reflect.MakeSlice(value.Type(), value.Len(), value.Len())
 		for i := range value.Len() {
-			cloned.Index(i).Set(cloneReflectValue(value.Index(i)))
+			clonedValue, err := cloneJSONLikeValue(value.Index(i), active)
+			if err != nil {
+				return reflect.Value{}, err
+			}
+			cloned.Index(i).Set(clonedValue)
 		}
-		return cloned
-	case reflect.Array:
-		cloned := reflect.New(value.Type()).Elem()
-		for i := range value.Len() {
-			cloned.Index(i).Set(cloneReflectValue(value.Index(i)))
+		return cloned, nil
+	case reflect.Bool, reflect.String,
+		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return value, nil
+	case reflect.Float32, reflect.Float64:
+		floatValue := value.Float()
+		if math.IsNaN(floatValue) || math.IsInf(floatValue, 0) {
+			return reflect.Value{}, fmt.Errorf("unsupported non-finite prompt diagnostics float %s: %w", value.Type(), ErrRedactionStructure)
 		}
-		return cloned
+		return value, nil
 	default:
-		return value
+		return reflect.Value{}, fmt.Errorf("unsupported prompt diagnostics value type %s: %w", value.Type(), ErrRedactionStructure)
 	}
+}
+
+func validateJSONNumber(number json.Number) error {
+	literal := number.String()
+	if !json.Valid([]byte(literal)) {
+		return fmt.Errorf("unsupported prompt diagnostics json.Number %q is not a valid JSON number: %w", literal, ErrRedactionStructure)
+	}
+	floatValue, err := number.Float64()
+	if err != nil {
+		return fmt.Errorf("unsupported prompt diagnostics json.Number %q: %v: %w", literal, err, ErrRedactionStructure)
+	}
+	if math.IsNaN(floatValue) || math.IsInf(floatValue, 0) {
+		return fmt.Errorf("unsupported non-finite prompt diagnostics json.Number %q: %w", literal, ErrRedactionStructure)
+	}
+	return nil
 }
 
 func cloneEventRecord(record EventRecord) EventRecord {

--- a/pkg/orchestrator/audit/audit_test.go
+++ b/pkg/orchestrator/audit/audit_test.go
@@ -234,6 +234,43 @@ func TestMulti_CloseClosesAllSinksAndJoinsErrors(t *testing.T) {
 	}
 }
 
+func TestMulti_CloseRetriesFailedChildrenUntilAllClose(t *testing.T) {
+	ctx := context.Background()
+	closeErr := errors.New("close failed")
+	first := &stubSink{}
+	second := &stubSink{closeErr: closeErr}
+	third := &stubSink{}
+	sink := Multi(first, second, third)
+
+	err := sink.Close(ctx)
+	if !errors.Is(err, closeErr) {
+		t.Fatalf("Close() error = %v, want %v", err, closeErr)
+	}
+	if first.closeCalls != 1 || second.closeCalls != 1 || third.closeCalls != 1 {
+		t.Fatalf("close calls after first close = %d/%d/%d, want 1/1/1", first.closeCalls, second.closeCalls, third.closeCalls)
+	}
+
+	writeErr := sink.WriteEvent(ctx, testEvent("task-1", EventTypeTaskCreated, 1))
+	if !errors.Is(writeErr, ErrSinkClosed) {
+		t.Fatalf("WriteEvent() after partial close error = %v, want ErrSinkClosed", writeErr)
+	}
+
+	second.closeErr = nil
+	if err := sink.Close(ctx); err != nil {
+		t.Fatalf("retry Close() error = %v, want nil", err)
+	}
+	if first.closeCalls != 1 || second.closeCalls != 2 || third.closeCalls != 1 {
+		t.Fatalf("close calls after retry = %d/%d/%d, want 1/2/1", first.closeCalls, second.closeCalls, third.closeCalls)
+	}
+
+	if err := sink.Close(ctx); err != nil {
+		t.Fatalf("idempotent Close() error = %v, want nil", err)
+	}
+	if first.closeCalls != 1 || second.closeCalls != 2 || third.closeCalls != 1 {
+		t.Fatalf("close calls after idempotent close = %d/%d/%d, want 1/2/1", first.closeCalls, second.closeCalls, third.closeCalls)
+	}
+}
+
 func TestMulti_CloseIsIdempotent(t *testing.T) {
 	ctx := context.Background()
 	underlying := &stubSink{}

--- a/pkg/orchestrator/audit/audit_test.go
+++ b/pkg/orchestrator/audit/audit_test.go
@@ -1,0 +1,486 @@
+package audit
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/AiRanthem/ANA/pkg/orchestrator/idgen"
+)
+
+func TestMemorySink_PreservesPerTaskOrder(t *testing.T) {
+	ctx := context.Background()
+	sink := NewMemorySink()
+	taskID := idgen.TaskID("task-1")
+
+	records := []EventRecord{
+		testEvent(taskID, EventTypeTaskCreated, 1),
+		testEvent(taskID, EventTypeRouteDirective, 2),
+		testEvent(taskID, EventTypeTaskCompleted, 3),
+	}
+	for _, record := range records {
+		if err := sink.WriteEvent(ctx, record); err != nil {
+			t.Fatalf("WriteEvent() error = %v", err)
+		}
+	}
+
+	got := sink.Events(taskID)
+	if len(got) != len(records) {
+		t.Fatalf("Events() len = %d, want %d", len(got), len(records))
+	}
+	for i := range records {
+		if got[i].Seq != records[i].Seq {
+			t.Fatalf("Events()[%d].Seq = %d, want %d", i, got[i].Seq, records[i].Seq)
+		}
+	}
+}
+
+func TestMemorySink_PreservesTranscriptInsertionOrder(t *testing.T) {
+	ctx := context.Background()
+	sink := NewMemorySink()
+	taskID := idgen.TaskID("task-ordering")
+
+	transcripts := []TranscriptRecord{
+		NewOutputTranscript(taskID, "session-1", "request-2", "first", 3, time.Unix(0, 3)),
+		NewOutputTranscript(taskID, "session-1", "request-1", "second", 1, time.Unix(0, 1)),
+		NewOutputTranscript(taskID, "session-1", "request-1", "third", 2, time.Unix(0, 2)),
+	}
+	for _, record := range transcripts {
+		if err := sink.WriteTranscript(ctx, record); err != nil {
+			t.Fatalf("WriteTranscript() error = %v", err)
+		}
+	}
+
+	got := sink.Transcripts(taskID)
+	if len(got) != len(transcripts) {
+		t.Fatalf("Transcripts() len = %d, want %d", len(got), len(transcripts))
+	}
+	wantContent := []string{"first", "second", "third"}
+	for i, expected := range wantContent {
+		if string(got[i].Content) != expected {
+			t.Fatalf("Transcripts()[%d].Content = %q, want %q", i, got[i].Content, expected)
+		}
+	}
+}
+
+func TestMulti_WritesToAllSinks(t *testing.T) {
+	ctx := context.Background()
+	first := NewMemorySink()
+	second := NewMemorySink()
+	sink := Multi(first, second)
+	record := testEvent("task-1", EventTypeSessionOpened, 1)
+
+	if err := sink.WriteEvent(ctx, record); err != nil {
+		t.Fatalf("WriteEvent() error = %v", err)
+	}
+
+	if got := first.Events(record.TaskID); len(got) != 1 {
+		t.Fatalf("first sink events len = %d, want 1", len(got))
+	}
+	if got := second.Events(record.TaskID); len(got) != 1 {
+		t.Fatalf("second sink events len = %d, want 1", len(got))
+	}
+}
+
+func TestMulti_FailsFastOnFailingSink(t *testing.T) {
+	ctx := context.Background()
+	failingErr := errors.New("durable sink unavailable")
+	first := NewMemorySink()
+	failing := &stubSink{writeEventErr: failingErr}
+	third := &stubSink{}
+	sink := Multi(first, failing, third)
+
+	err := sink.WriteEvent(ctx, testEvent("task-1", EventTypeRequestFailed, 1))
+	if !errors.Is(err, failingErr) {
+		t.Fatalf("WriteEvent() error = %v, want %v", err, failingErr)
+	}
+	if third.writeEventCalls != 0 {
+		t.Fatalf("third sink WriteEvent calls = %d, want 0", third.writeEventCalls)
+	}
+}
+
+func TestMulti_EmptySinkFailsInsteadOfDropping(t *testing.T) {
+	ctx := context.Background()
+	sink := Multi(nil)
+
+	err := sink.WriteEvent(ctx, testEvent("task-1", EventTypeTaskCreated, 1))
+	if !errors.Is(err, ErrNoSink) {
+		t.Fatalf("WriteEvent() error = %v, want ErrNoSink", err)
+	}
+}
+
+func TestMulti_CloseWithNoSinksIsNoop(t *testing.T) {
+	ctx := context.Background()
+	sink := Multi(nil)
+
+	if err := sink.Close(ctx); err != nil {
+		t.Fatalf("Close() error = %v, want nil for empty Multi", err)
+	}
+}
+
+func TestMulti_PropagatesFirstFailingTranscriptError(t *testing.T) {
+	ctx := context.Background()
+	wantErr := errors.New("disk full")
+	first := NewMemorySink()
+	failing := &stubSink{writeTranscriptErr: wantErr}
+	third := &stubSink{}
+	sink := Multi(first, failing, third)
+
+	record := TranscriptRecord{
+		TaskID:      "task-1",
+		SessionID:   "session-1",
+		RequestID:   "request-1",
+		Kind:        TranscriptKindOutput,
+		Content:     []byte("output"),
+		ContentType: "text/plain",
+		Seq:         1,
+		Schema:      SchemaV1,
+		CreatedAt:   time.Now(),
+	}
+
+	err := sink.WriteTranscript(ctx, record)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("WriteTranscript() error = %v, want wrapping %v", err, wantErr)
+	}
+	if got := first.Transcripts("task-1"); len(got) != 1 {
+		t.Fatalf("first sink transcripts len = %d, want 1 (written before failure)", len(got))
+	}
+	if third.writeTranscriptCalls != 0 {
+		t.Fatalf("third sink writeTranscriptCalls = %d, want 0 (Multi must short-circuit on failure)", third.writeTranscriptCalls)
+	}
+}
+
+func TestInputTranscript_CanStoreFullyRenderedRequestShape(t *testing.T) {
+	ctx := context.Background()
+	sink := NewMemorySink()
+	content := FullyRenderedRequest{
+		TaskID:         "task-1",
+		SessionID:      "session-1",
+		RequestID:      "request-1",
+		WorkspaceID:    "workspace-1",
+		WorkspaceAlias: "Alice",
+		AgentKey:       "claude-code",
+		RuntimeType:    "cli",
+		RuntimeKind:    "resumable_cli",
+		Inputs: []RenderedInputPart{
+			{
+				Role:         "system",
+				Kind:         "text",
+				Content:      "Notes:\n- Bob",
+				SizeBytes:    len("Notes:\n- Bob"),
+				Redacted:     false,
+				RedactionTag: "",
+			},
+			{
+				Role:      "user",
+				Kind:      "text",
+				Content:   "check stock prices",
+				SizeBytes: len("check stock prices"),
+			},
+		},
+		Attachments: []AttachmentMetadata{
+			{
+				Kind:      "file",
+				Name:      "portfolio.csv",
+				Reference: "blob://portfolio",
+				SizeBytes: 128,
+				Digest:    "sha256:abc",
+				Redacted:  false,
+			},
+		},
+		PromptDiagnostics: map[string]any{
+			"notes_included": true,
+		},
+		RegistrySnapshot: json.RawMessage(`{"partners":["Bob"]}`),
+	}
+	record, err := NewInputTranscript(content, 1, time.Now())
+	if err != nil {
+		t.Fatalf("NewInputTranscript() error = %v", err)
+	}
+	if err := sink.WriteTranscript(ctx, record); err != nil {
+		t.Fatalf("WriteTranscript() error = %v", err)
+	}
+
+	got := sink.Transcripts("task-1")
+	if len(got) != 1 {
+		t.Fatalf("Transcripts() len = %d, want 1", len(got))
+	}
+	if got[0].Kind != TranscriptKindInput {
+		t.Fatalf("Kind = %q, want %q", got[0].Kind, TranscriptKindInput)
+	}
+	var decoded FullyRenderedRequest
+	if err := json.Unmarshal(got[0].Content, &decoded); err != nil {
+		t.Fatalf("input transcript content is not JSON: %v", err)
+	}
+	if decoded.WorkspaceAlias != "Alice" || decoded.RuntimeKind != "resumable_cli" {
+		t.Fatalf("decoded workspace/runtime = %q/%q, want Alice/resumable_cli", decoded.WorkspaceAlias, decoded.RuntimeKind)
+	}
+	if len(decoded.Inputs) != 2 || decoded.Inputs[0].Content != "Notes:\n- Bob" || decoded.Inputs[1].Content != "check stock prices" {
+		t.Fatalf("decoded inputs = %#v, want fully rendered ordered inputs", decoded.Inputs)
+	}
+	if len(decoded.Attachments) != 1 || decoded.Attachments[0].Digest != "sha256:abc" {
+		t.Fatalf("decoded attachments = %#v, want digest metadata preserved", decoded.Attachments)
+	}
+}
+
+func TestRedactionPolicy_PreservesStructuralMetadata(t *testing.T) {
+	content := FullyRenderedRequest{
+		TaskID:         "task-1",
+		SessionID:      "session-1",
+		RequestID:      "request-1",
+		WorkspaceID:    "workspace-1",
+		WorkspaceAlias: "Alice",
+		AgentKey:       "agent-key",
+		RuntimeType:    "cli",
+		RuntimeKind:    "resumable_cli",
+		Inputs: []RenderedInputPart{
+			{Role: "user", Kind: "text", Content: "secret", SizeBytes: 6},
+		},
+		Attachments: []AttachmentMetadata{
+			{Kind: "file", Name: "secret.txt", Reference: "blob://secret", SizeBytes: 10, Digest: "sha256:secret"},
+		},
+	}
+	policy := RedactionPolicyFunc(func(in FullyRenderedRequest) (FullyRenderedRequest, error) {
+		out := in
+		out.Inputs[0].Content = "[redacted]"
+		out.Inputs[0].Redacted = true
+		out.Inputs[0].RedactionTag = "secret"
+		out.Attachments[0].Name = "[redacted]"
+		out.Attachments[0].Redacted = true
+		out.Attachments[0].RedactionTag = "secret"
+		return out, nil
+	})
+
+	redacted, err := ApplyRedaction(content, policy)
+	if err != nil {
+		t.Fatalf("ApplyRedaction() error = %v", err)
+	}
+
+	if redacted.TaskID == "" || redacted.SessionID == "" || redacted.RequestID == "" {
+		t.Fatalf("redacted required IDs = %#v, want preserved", redacted)
+	}
+	if redacted.WorkspaceID != "workspace-1" || redacted.WorkspaceAlias != "Alice" || redacted.RuntimeType != "cli" || redacted.RuntimeKind != "resumable_cli" {
+		t.Fatalf("redacted workspace/runtime metadata = %#v, want preserved", redacted)
+	}
+	if len(redacted.Inputs) != 1 || redacted.Inputs[0].Role != "user" || redacted.Inputs[0].Kind != "text" || redacted.Inputs[0].SizeBytes != 6 {
+		t.Fatalf("redacted input structure = %#v, want role/kind/size preserved", redacted.Inputs)
+	}
+	if len(redacted.Attachments) != 1 || redacted.Attachments[0].Kind != "file" || redacted.Attachments[0].Reference != "blob://secret" || redacted.Attachments[0].Digest != "sha256:secret" {
+		t.Fatalf("redacted attachment structure = %#v, want reference/digest preserved", redacted.Attachments)
+	}
+}
+
+func TestRedactionPolicy_CannotDropStructuralMetadata(t *testing.T) {
+	content := FullyRenderedRequest{
+		TaskID:         "task-1",
+		SessionID:      "session-1",
+		RequestID:      "request-1",
+		WorkspaceID:    "workspace-1",
+		WorkspaceAlias: "Alice",
+		AgentKey:       "agent-key",
+		RuntimeType:    "cli",
+		RuntimeKind:    "resumable_cli",
+		Inputs: []RenderedInputPart{
+			{Role: "system", Kind: "text", Content: "notes", SizeBytes: 5},
+			{Role: "user", Kind: "text", Content: "secret", SizeBytes: 6},
+		},
+		Attachments: []AttachmentMetadata{
+			{Kind: "file", Reference: "blob://secret", SizeBytes: 10, Digest: "sha256:secret"},
+		},
+	}
+	policy := RedactionPolicyFunc(func(in FullyRenderedRequest) (FullyRenderedRequest, error) {
+		out := in
+		out.Inputs = out.Inputs[:1]
+		out.Attachments = nil
+		return out, nil
+	})
+
+	_, err := ApplyRedaction(content, policy)
+	if !errors.Is(err, ErrRedactionStructure) {
+		t.Fatalf("ApplyRedaction() error = %v, want ErrRedactionStructure", err)
+	}
+}
+
+func TestRedactionPolicy_InPlaceMutationCannotCorruptStructuralMetadata(t *testing.T) {
+	content := FullyRenderedRequest{
+		TaskID:         "task-1",
+		SessionID:      "session-1",
+		RequestID:      "request-1",
+		WorkspaceID:    "workspace-1",
+		WorkspaceAlias: "Alice",
+		AgentKey:       "agent-key",
+		RuntimeType:    "cli",
+		RuntimeKind:    "resumable_cli",
+		Inputs: []RenderedInputPart{
+			{
+				Role:             "user",
+				Kind:             "text",
+				Content:          "secret",
+				ContentReference: "content://canonical",
+				SizeBytes:        6,
+				SourceReference:  "message://source",
+				Metadata:         map[string]string{"source": "user"},
+			},
+		},
+		Attachments: []AttachmentMetadata{
+			{
+				Kind:      "file",
+				Name:      "secret.txt",
+				Reference: "blob://secret",
+				SizeBytes: 10,
+				Digest:    "sha256:secret",
+				Metadata:  map[string]string{"name": "secret.txt"},
+			},
+		},
+		PromptDiagnostics: map[string]any{
+			"notes_included": true,
+			"nested": map[string]any{
+				"steps": []any{"registry", "notes"},
+			},
+			"typed": []map[string]any{
+				{"decision": map[string][]string{"sources": {"registry"}}},
+			},
+		},
+		RegistrySnapshot:  json.RawMessage(`{"partners":["Bob"]}`),
+		RegistryReference: "registry://snapshot-1",
+		TemplateVersion:   "prompt-v1",
+		Metadata:          map[string]string{"request": "root"},
+	}
+	policy := RedactionPolicyFunc(func(in FullyRenderedRequest) (FullyRenderedRequest, error) {
+		in.TaskID = "wrong-task"
+		in.Inputs[0].Role = "assistant"
+		in.Inputs[0].Kind = "json"
+		in.Inputs[0].ContentReference = "content://wrong"
+		in.Inputs[0].SizeBytes = 999
+		in.Inputs[0].SourceReference = "wrong-source"
+		in.Inputs[0].Metadata["source"] = "wrong"
+		in.Attachments[0].Kind = "url"
+		in.Attachments[0].Reference = "https://wrong"
+		in.Attachments[0].SizeBytes = 999
+		in.Attachments[0].Digest = "sha256:wrong"
+		in.Attachments[0].Metadata["name"] = "wrong"
+		in.PromptDiagnostics["notes_included"] = false
+		nested := in.PromptDiagnostics["nested"].(map[string]any)
+		steps := nested["steps"].([]any)
+		steps[0] = "wrong"
+		nested["steps"] = steps
+		typed := in.PromptDiagnostics["typed"].([]map[string]any)
+		decision := typed[0]["decision"].(map[string][]string)
+		decision["sources"][0] = "wrong"
+		in.RegistrySnapshot = json.RawMessage(`{"partners":["Mallory"]}`)
+		in.RegistryReference = "registry://wrong"
+		in.TemplateVersion = "prompt-wrong"
+		in.Metadata["request"] = "wrong"
+		return in, nil
+	})
+
+	redacted, err := ApplyRedaction(content, policy)
+	if err != nil {
+		t.Fatalf("ApplyRedaction() error = %v", err)
+	}
+
+	if redacted.TaskID != "task-1" || redacted.Inputs[0].Role != "user" || redacted.Inputs[0].Kind != "text" || redacted.Inputs[0].ContentReference != "content://canonical" || redacted.Inputs[0].SizeBytes != 6 || redacted.Inputs[0].SourceReference != "message://source" {
+		t.Fatalf("redacted input structure = %#v, want original structural metadata restored", redacted)
+	}
+	if redacted.Inputs[0].Metadata["source"] != "user" {
+		t.Fatalf("redacted input metadata = %#v, want original metadata preserved", redacted.Inputs[0].Metadata)
+	}
+	if redacted.Attachments[0].Kind != "file" || redacted.Attachments[0].Reference != "blob://secret" || redacted.Attachments[0].SizeBytes != 10 || redacted.Attachments[0].Digest != "sha256:secret" {
+		t.Fatalf("redacted attachment structure = %#v, want original structural metadata restored", redacted.Attachments[0])
+	}
+	nested := redacted.PromptDiagnostics["nested"].(map[string]any)
+	steps := nested["steps"].([]any)
+	typed := redacted.PromptDiagnostics["typed"].([]map[string]any)
+	decision := typed[0]["decision"].(map[string][]string)
+	if redacted.Attachments[0].Metadata["name"] != "secret.txt" || redacted.PromptDiagnostics["notes_included"] != false || steps[0] != "wrong" || decision["sources"][0] != "wrong" || string(redacted.RegistrySnapshot) != `{"partners":["Mallory"]}` || redacted.RegistryReference != "registry://snapshot-1" || redacted.TemplateVersion != "prompt-v1" || redacted.Metadata["request"] != "wrong" {
+		t.Fatalf("redacted maps/references = input %#v attachment %#v diagnostics %#v snapshot %s reference %q template %q metadata %#v, want policy redactions plus replay references preserved", redacted.Inputs[0].Metadata, redacted.Attachments[0].Metadata, redacted.PromptDiagnostics, redacted.RegistrySnapshot, redacted.RegistryReference, redacted.TemplateVersion, redacted.Metadata)
+	}
+	originalNested := content.PromptDiagnostics["nested"].(map[string]any)
+	originalSteps := originalNested["steps"].([]any)
+	originalTyped := content.PromptDiagnostics["typed"].([]map[string]any)
+	originalDecision := originalTyped[0]["decision"].(map[string][]string)
+	if content.Inputs[0].Role != "user" || content.Inputs[0].ContentReference != "content://canonical" || content.Attachments[0].Digest != "sha256:secret" || originalSteps[0] != "registry" || originalDecision["sources"][0] != "registry" || string(content.RegistrySnapshot) != `{"partners":["Bob"]}` || content.RegistryReference != "registry://snapshot-1" || content.TemplateVersion != "prompt-v1" || content.Metadata["request"] != "root" {
+		t.Fatalf("original request mutated: %#v", content)
+	}
+}
+
+func TestMemorySink_ConcurrentWritesAreSafe(t *testing.T) {
+	ctx := context.Background()
+	sink := NewMemorySink()
+	taskID := idgen.TaskID("task-1")
+	const writers = 32
+	const writesPerWriter = 50
+
+	var wg sync.WaitGroup
+	for writer := range writers {
+		wg.Add(1)
+		go func(writer int) {
+			defer wg.Done()
+			for seq := range writesPerWriter {
+				record := testEvent(taskID, EventTypeRequestTextChunk, uint64(writer*writesPerWriter+seq))
+				if err := sink.WriteEvent(ctx, record); err != nil {
+					t.Errorf("WriteEvent() error = %v", err)
+				}
+			}
+		}(writer)
+	}
+	wg.Wait()
+
+	got := sink.Events(taskID)
+	if len(got) != writers*writesPerWriter {
+		t.Fatalf("Events() len = %d, want %d", len(got), writers*writesPerWriter)
+	}
+}
+
+func TestMemorySink_CloseRejectsWrites(t *testing.T) {
+	ctx := context.Background()
+	sink := NewMemorySink()
+	if err := sink.Close(ctx); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	err := sink.WriteEvent(ctx, testEvent("task-1", EventTypeTaskCreated, 1))
+	if !errors.Is(err, ErrSinkClosed) {
+		t.Fatalf("WriteEvent() error = %v, want ErrSinkClosed", err)
+	}
+}
+
+func testEvent(taskID idgen.TaskID, typ EventType, seq uint64) EventRecord {
+	return EventRecord{
+		EventID:    fmt.Sprintf("event-%d", seq),
+		TaskID:     taskID,
+		SessionID:  "session-1",
+		RequestID:  "request-1",
+		Type:       typ,
+		Seq:        seq,
+		OccurredAt: time.Unix(0, int64(seq)),
+		Payload:    []byte(`{"ok":true}`),
+		Schema:     SchemaV1,
+	}
+}
+
+type stubSink struct {
+	writeEventErr        error
+	writeTranscriptErr   error
+	closeErr             error
+	writeEventCalls      int
+	writeTranscriptCalls int
+}
+
+func (s *stubSink) WriteEvent(ctx context.Context, record EventRecord) error {
+	s.writeEventCalls++
+	return s.writeEventErr
+}
+
+func (s *stubSink) WriteTranscript(ctx context.Context, record TranscriptRecord) error {
+	s.writeTranscriptCalls++
+	return s.writeTranscriptErr
+}
+
+func (s *stubSink) Close(ctx context.Context) error {
+	return s.closeErr
+}

--- a/pkg/orchestrator/audit/audit_test.go
+++ b/pkg/orchestrator/audit/audit_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"sync"
 	"testing"
 	"time"
@@ -113,6 +114,16 @@ func TestMulti_EmptySinkFailsInsteadOfDropping(t *testing.T) {
 	}
 }
 
+func TestMulti_EmptySinkTranscriptFailsInsteadOfDropping(t *testing.T) {
+	ctx := context.Background()
+	sink := Multi(nil)
+
+	err := sink.WriteTranscript(ctx, NewOutputTranscript("task-1", "session-1", "request-1", "output", 1, time.Now()))
+	if !errors.Is(err, ErrNoSink) {
+		t.Fatalf("WriteTranscript() error = %v, want ErrNoSink", err)
+	}
+}
+
 func TestMulti_CloseWithNoSinksIsNoop(t *testing.T) {
 	ctx := context.Background()
 	sink := Multi(nil)
@@ -151,6 +162,138 @@ func TestMulti_PropagatesFirstFailingTranscriptError(t *testing.T) {
 	}
 	if third.writeTranscriptCalls != 0 {
 		t.Fatalf("third sink writeTranscriptCalls = %d, want 0 (Multi must short-circuit on failure)", third.writeTranscriptCalls)
+	}
+}
+
+func TestMulti_ConcurrentWritesCannotInterleaveFanout(t *testing.T) {
+	ctx := context.Background()
+	first := newBlockingFanoutSink()
+	second := &recordingSink{}
+	sink := Multi(first, second)
+
+	firstDone := make(chan error, 1)
+	go func() {
+		record := testEvent("task-1", EventTypeRequestRunning, 1)
+		err := sink.WriteEvent(ctx, record)
+		firstDone <- err
+	}()
+	if err := first.waitForFirstCall(); err != nil {
+		t.Fatal(err)
+	}
+
+	secondStarted := make(chan struct{})
+	secondDone := make(chan error, 1)
+	go func() {
+		close(secondStarted)
+		record := testEvent("task-1", EventTypeRequestTextChunk, 2)
+		secondDone <- sink.WriteEvent(ctx, record)
+	}()
+	select {
+	case <-secondStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for second write goroutine to start")
+	}
+
+	select {
+	case <-first.secondCallStarted:
+		t.Fatal("second write reached the first underlying sink before the first write completed fan-out")
+	case <-time.After(20 * time.Millisecond):
+	}
+	if got := second.eventSeqs(); len(got) != 0 {
+		t.Fatalf("second sink event seqs = %v, want none before first write is released", got)
+	}
+
+	first.releaseFirstCall()
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first WriteEvent() error = %v", err)
+	}
+	if err := <-secondDone; err != nil {
+		t.Fatalf("second WriteEvent() error = %v", err)
+	}
+
+	if got := second.eventSeqs(); len(got) != 2 || got[0] != 1 || got[1] != 2 {
+		t.Fatalf("second sink event seqs = %v, want [1 2]", got)
+	}
+}
+
+func TestMulti_CloseClosesAllSinksAndJoinsErrors(t *testing.T) {
+	ctx := context.Background()
+	firstErr := errors.New("first close failed")
+	thirdErr := errors.New("third close failed")
+	first := &stubSink{closeErr: firstErr}
+	second := &stubSink{}
+	third := &stubSink{closeErr: thirdErr}
+	sink := Multi(first, second, third)
+
+	err := sink.Close(ctx)
+	if !errors.Is(err, firstErr) || !errors.Is(err, thirdErr) {
+		t.Fatalf("Close() error = %v, want both close errors", err)
+	}
+	if first.closeCalls != 1 || second.closeCalls != 1 || third.closeCalls != 1 {
+		t.Fatalf("close calls = %d/%d/%d, want 1/1/1", first.closeCalls, second.closeCalls, third.closeCalls)
+	}
+}
+
+func TestMulti_CloseIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	underlying := &stubSink{}
+	sink := Multi(underlying)
+
+	if err := sink.Close(ctx); err != nil {
+		t.Fatalf("first Close() error = %v", err)
+	}
+	if err := sink.Close(ctx); err != nil {
+		t.Fatalf("second Close() error = %v, want nil", err)
+	}
+	if underlying.closeCalls != 1 {
+		t.Fatalf("underlying Close calls = %d, want 1", underlying.closeCalls)
+	}
+}
+
+func TestMulti_CloseRejectsWrites(t *testing.T) {
+	ctx := context.Background()
+	sink := Multi(&stubSink{})
+	if err := sink.Close(ctx); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	eventErr := sink.WriteEvent(ctx, testEvent("task-1", EventTypeTaskCreated, 1))
+	if !errors.Is(eventErr, ErrSinkClosed) {
+		t.Fatalf("WriteEvent() error = %v, want ErrSinkClosed", eventErr)
+	}
+	transcriptErr := sink.WriteTranscript(ctx, NewOutputTranscript("task-1", "session-1", "request-1", "output", 1, time.Now()))
+	if !errors.Is(transcriptErr, ErrSinkClosed) {
+		t.Fatalf("WriteTranscript() error = %v, want ErrSinkClosed", transcriptErr)
+	}
+}
+
+func TestMulti_CanceledContextRejectsWriteAndClose(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	underlying := &stubSink{}
+	sink := Multi(underlying)
+
+	err := sink.WriteEvent(ctx, testEvent("task-1", EventTypeTaskCreated, 1))
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("WriteEvent() error = %v, want context.Canceled", err)
+	}
+	if underlying.writeEventCalls != 0 {
+		t.Fatalf("underlying WriteEvent calls = %d, want 0", underlying.writeEventCalls)
+	}
+
+	err = sink.Close(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Close() error = %v, want context.Canceled", err)
+	}
+	if underlying.closeCalls != 0 {
+		t.Fatalf("underlying Close calls = %d, want 0 for pre-canceled context", underlying.closeCalls)
+	}
+
+	if err := sink.Close(context.Background()); err != nil {
+		t.Fatalf("Close() after canceled attempt error = %v", err)
+	}
+	if underlying.closeCalls != 1 {
+		t.Fatalf("underlying Close calls after active close = %d, want 1", underlying.closeCalls)
 	}
 }
 
@@ -224,6 +367,49 @@ func TestInputTranscript_CanStoreFullyRenderedRequestShape(t *testing.T) {
 	}
 	if len(decoded.Attachments) != 1 || decoded.Attachments[0].Digest != "sha256:abc" {
 		t.Fatalf("decoded attachments = %#v, want digest metadata preserved", decoded.Attachments)
+	}
+}
+
+func TestEventSummaryTranscript_UsesStableJSONShape(t *testing.T) {
+	message := "agent failed"
+	record, err := NewEventSummaryTranscript(
+		"task-1",
+		"session-1",
+		"request-1",
+		EventSummary{
+			Usage: UsageSummary{
+				PromptTokens:     11,
+				CompletionTokens: 7,
+				TotalTokens:      18,
+			},
+			FinishReason: "stop",
+			ToolCalls:    2,
+			ToolResults:  1,
+			Error:        &message,
+			DurationMS:   123,
+		},
+		4,
+		time.Unix(0, 4),
+	)
+	if err != nil {
+		t.Fatalf("NewEventSummaryTranscript() error = %v", err)
+	}
+	if record.Kind != TranscriptKindEventSummary || record.ContentType != "application/json" {
+		t.Fatalf("record kind/content type = %q/%q, want event_summary application/json", record.Kind, record.ContentType)
+	}
+
+	want := `{"usage":{"prompt_tokens":11,"completion_tokens":7,"total_tokens":18},"finish_reason":"stop","tool_calls":2,"tool_results":1,"error":"agent failed","duration_ms":123}`
+	if string(record.Content) != want {
+		t.Fatalf("Content = %s, want %s", record.Content, want)
+	}
+
+	record, err = NewEventSummaryTranscript("task-1", "session-1", "request-1", EventSummary{}, 5, time.Unix(0, 5))
+	if err != nil {
+		t.Fatalf("NewEventSummaryTranscript() zero value error = %v", err)
+	}
+	want = `{"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0},"finish_reason":"","tool_calls":0,"tool_results":0,"error":null,"duration_ms":0}`
+	if string(record.Content) != want {
+		t.Fatalf("zero-value Content = %s, want %s", record.Content, want)
 	}
 }
 
@@ -305,6 +491,373 @@ func TestRedactionPolicy_CannotDropStructuralMetadata(t *testing.T) {
 	}
 }
 
+func TestRedactionPolicy_CannotClearInputContentWithoutReplayMarker(t *testing.T) {
+	content := FullyRenderedRequest{
+		TaskID:         "task-1",
+		SessionID:      "session-1",
+		RequestID:      "request-1",
+		WorkspaceID:    "workspace-1",
+		WorkspaceAlias: "Alice",
+		AgentKey:       "agent-key",
+		RuntimeType:    "cli",
+		RuntimeKind:    "resumable_cli",
+		Inputs: []RenderedInputPart{
+			{Role: "user", Kind: "text", Content: "secret", SizeBytes: 6},
+		},
+	}
+	policy := RedactionPolicyFunc(func(in FullyRenderedRequest) (FullyRenderedRequest, error) {
+		in.Inputs[0].Content = ""
+		return in, nil
+	})
+
+	_, err := ApplyRedaction(content, policy)
+	if !errors.Is(err, ErrRedactionStructure) {
+		t.Fatalf("ApplyRedaction() error = %v, want ErrRedactionStructure", err)
+	}
+}
+
+func TestRedactionPolicy_CannotReplaceInputContentWithoutRedactionMarker(t *testing.T) {
+	content := FullyRenderedRequest{
+		TaskID:         "task-1",
+		SessionID:      "session-1",
+		RequestID:      "request-1",
+		WorkspaceID:    "workspace-1",
+		WorkspaceAlias: "Alice",
+		AgentKey:       "agent-key",
+		RuntimeType:    "cli",
+		RuntimeKind:    "resumable_cli",
+		Inputs: []RenderedInputPart{
+			{Role: "user", Kind: "text", Content: "secret prompt", SizeBytes: 13},
+		},
+	}
+	policy := RedactionPolicyFunc(func(in FullyRenderedRequest) (FullyRenderedRequest, error) {
+		in.Inputs[0].Content = "ok"
+		return in, nil
+	})
+
+	_, err := ApplyRedaction(content, policy)
+	if !errors.Is(err, ErrRedactionStructure) {
+		t.Fatalf("ApplyRedaction() error = %v, want ErrRedactionStructure", err)
+	}
+}
+
+func TestRedactionPolicy_AllowsInputContentRedactionWithMarker(t *testing.T) {
+	content := FullyRenderedRequest{
+		TaskID:         "task-1",
+		SessionID:      "session-1",
+		RequestID:      "request-1",
+		WorkspaceID:    "workspace-1",
+		WorkspaceAlias: "Alice",
+		AgentKey:       "agent-key",
+		RuntimeType:    "cli",
+		RuntimeKind:    "resumable_cli",
+		Inputs: []RenderedInputPart{
+			{Role: "user", Kind: "text", Content: "secret prompt", SizeBytes: 13},
+		},
+	}
+	policy := RedactionPolicyFunc(func(in FullyRenderedRequest) (FullyRenderedRequest, error) {
+		in.Inputs[0].Content = "[redacted]"
+		in.Inputs[0].Redacted = true
+		in.Inputs[0].RedactionTag = "secret"
+		return in, nil
+	})
+
+	redacted, err := ApplyRedaction(content, policy)
+	if err != nil {
+		t.Fatalf("ApplyRedaction() error = %v", err)
+	}
+	if redacted.Inputs[0].Content != "[redacted]" || !redacted.Inputs[0].Redacted || redacted.Inputs[0].RedactionTag != "secret" {
+		t.Fatalf("redacted input = %#v, want content redacted with marker", redacted.Inputs[0])
+	}
+}
+
+func TestRedactionPolicy_CannotClearAttachmentNameWithoutReplayMarker(t *testing.T) {
+	content := FullyRenderedRequest{
+		TaskID:         "task-1",
+		SessionID:      "session-1",
+		RequestID:      "request-1",
+		WorkspaceID:    "workspace-1",
+		WorkspaceAlias: "Alice",
+		AgentKey:       "agent-key",
+		RuntimeType:    "cli",
+		RuntimeKind:    "resumable_cli",
+		Inputs: []RenderedInputPart{
+			{Role: "user", Kind: "text", Content: "ok", SizeBytes: 2},
+		},
+		Attachments: []AttachmentMetadata{
+			{Kind: "file", Name: "secret.txt", SizeBytes: 10},
+		},
+	}
+	policy := RedactionPolicyFunc(func(in FullyRenderedRequest) (FullyRenderedRequest, error) {
+		in.Attachments[0].Name = ""
+		return in, nil
+	})
+
+	_, err := ApplyRedaction(content, policy)
+	if !errors.Is(err, ErrRedactionStructure) {
+		t.Fatalf("ApplyRedaction() error = %v, want ErrRedactionStructure", err)
+	}
+}
+
+func TestRedactionPolicy_CannotReplaceAttachmentNameWithoutRedactionMarker(t *testing.T) {
+	content := FullyRenderedRequest{
+		TaskID:         "task-1",
+		SessionID:      "session-1",
+		RequestID:      "request-1",
+		WorkspaceID:    "workspace-1",
+		WorkspaceAlias: "Alice",
+		AgentKey:       "agent-key",
+		RuntimeType:    "cli",
+		RuntimeKind:    "resumable_cli",
+		Inputs: []RenderedInputPart{
+			{Role: "user", Kind: "text", Content: "ok", SizeBytes: 2},
+		},
+		Attachments: []AttachmentMetadata{
+			{Kind: "file", Name: "secret.txt", Reference: "blob://secret", SizeBytes: 10, Digest: "sha256:secret"},
+		},
+	}
+	policy := RedactionPolicyFunc(func(in FullyRenderedRequest) (FullyRenderedRequest, error) {
+		in.Attachments[0].Name = "ok.txt"
+		return in, nil
+	})
+
+	_, err := ApplyRedaction(content, policy)
+	if !errors.Is(err, ErrRedactionStructure) {
+		t.Fatalf("ApplyRedaction() error = %v, want ErrRedactionStructure", err)
+	}
+}
+
+func TestRedactionPolicy_AllowsAttachmentNameRedactionWithMarker(t *testing.T) {
+	content := FullyRenderedRequest{
+		TaskID:         "task-1",
+		SessionID:      "session-1",
+		RequestID:      "request-1",
+		WorkspaceID:    "workspace-1",
+		WorkspaceAlias: "Alice",
+		AgentKey:       "agent-key",
+		RuntimeType:    "cli",
+		RuntimeKind:    "resumable_cli",
+		Inputs: []RenderedInputPart{
+			{Role: "user", Kind: "text", Content: "ok", SizeBytes: 2},
+		},
+		Attachments: []AttachmentMetadata{
+			{Kind: "file", Name: "secret.txt", Reference: "blob://secret", SizeBytes: 10, Digest: "sha256:secret"},
+		},
+	}
+	policy := RedactionPolicyFunc(func(in FullyRenderedRequest) (FullyRenderedRequest, error) {
+		in.Attachments[0].Name = "[redacted]"
+		in.Attachments[0].Redacted = true
+		in.Attachments[0].RedactionTag = "secret"
+		return in, nil
+	})
+
+	redacted, err := ApplyRedaction(content, policy)
+	if err != nil {
+		t.Fatalf("ApplyRedaction() error = %v", err)
+	}
+	if redacted.Attachments[0].Name != "[redacted]" || redacted.Attachments[0].Reference != "blob://secret" || redacted.Attachments[0].Digest != "sha256:secret" || !redacted.Attachments[0].Redacted || redacted.Attachments[0].RedactionTag != "secret" {
+		t.Fatalf("redacted attachment = %#v, want name redacted with reference/digest preserved", redacted.Attachments[0])
+	}
+}
+
+func TestRedactionPolicy_AllowsAttachmentMetadataRedactionWithMarker(t *testing.T) {
+	content := FullyRenderedRequest{
+		TaskID:         "task-1",
+		SessionID:      "session-1",
+		RequestID:      "request-1",
+		WorkspaceID:    "workspace-1",
+		WorkspaceAlias: "Alice",
+		AgentKey:       "agent-key",
+		RuntimeType:    "cli",
+		RuntimeKind:    "resumable_cli",
+		Inputs: []RenderedInputPart{
+			{Role: "user", Kind: "text", Content: "ok", SizeBytes: 2},
+		},
+		Attachments: []AttachmentMetadata{
+			{
+				Kind:      "file",
+				Name:      "secret.txt",
+				Reference: "blob://secret",
+				SizeBytes: 10,
+				Digest:    "sha256:secret",
+				Metadata:  map[string]string{"path": "/tmp/secret.txt", "owner": "alice"},
+			},
+		},
+	}
+	policy := RedactionPolicyFunc(func(in FullyRenderedRequest) (FullyRenderedRequest, error) {
+		in.Attachments[0].Name = "[redacted]"
+		in.Attachments[0].Metadata["path"] = "[redacted]"
+		in.Attachments[0].Redacted = true
+		in.Attachments[0].RedactionTag = "secret"
+		return in, nil
+	})
+
+	redacted, err := ApplyRedaction(content, policy)
+	if err != nil {
+		t.Fatalf("ApplyRedaction() error = %v", err)
+	}
+	if redacted.Attachments[0].Reference != "blob://secret" || redacted.Attachments[0].Digest != "sha256:secret" {
+		t.Fatalf("redacted attachment = %#v, want reference/digest preserved", redacted.Attachments[0])
+	}
+	if redacted.Attachments[0].Metadata["path"] != "[redacted]" || redacted.Attachments[0].Metadata["owner"] != "alice" {
+		t.Fatalf("redacted attachment metadata = %#v, want policy-redacted metadata", redacted.Attachments[0].Metadata)
+	}
+}
+
+func TestRedactionPolicy_AllowsInputMetadataRedactionWithMarker(t *testing.T) {
+	content := FullyRenderedRequest{
+		TaskID:         "task-1",
+		SessionID:      "session-1",
+		RequestID:      "request-1",
+		WorkspaceID:    "workspace-1",
+		WorkspaceAlias: "Alice",
+		AgentKey:       "agent-key",
+		RuntimeType:    "cli",
+		RuntimeKind:    "resumable_cli",
+		Inputs: []RenderedInputPart{
+			{
+				Role:             "user",
+				Kind:             "text",
+				Content:          "[redacted]",
+				ContentReference: "content://canonical",
+				SizeBytes:        20,
+				SourceReference:  "message://source",
+				Metadata:         map[string]string{"path": "/tmp/secret.txt", "source": "user"},
+				Redacted:         true,
+				RedactionTag:     "secret",
+			},
+		},
+	}
+	policy := RedactionPolicyFunc(func(in FullyRenderedRequest) (FullyRenderedRequest, error) {
+		in.Inputs[0].Metadata["path"] = "[redacted]"
+		return in, nil
+	})
+
+	redacted, err := ApplyRedaction(content, policy)
+	if err != nil {
+		t.Fatalf("ApplyRedaction() error = %v", err)
+	}
+	if redacted.Inputs[0].ContentReference != "content://canonical" || redacted.Inputs[0].SourceReference != "message://source" {
+		t.Fatalf("redacted input = %#v, want replay-critical references preserved", redacted.Inputs[0])
+	}
+	if redacted.Inputs[0].Metadata["path"] != "[redacted]" || redacted.Inputs[0].Metadata["source"] != "user" {
+		t.Fatalf("redacted input metadata = %#v, want policy-redacted metadata", redacted.Inputs[0].Metadata)
+	}
+}
+
+func TestRedactionPolicy_CannotDropRegistryContext(t *testing.T) {
+	content := FullyRenderedRequest{
+		TaskID:           "task-1",
+		SessionID:        "session-1",
+		RequestID:        "request-1",
+		WorkspaceID:      "workspace-1",
+		WorkspaceAlias:   "Alice",
+		AgentKey:         "agent-key",
+		RuntimeType:      "cli",
+		RuntimeKind:      "resumable_cli",
+		RegistrySnapshot: json.RawMessage(`{"partners":["Bob"]}`),
+		Inputs: []RenderedInputPart{
+			{Role: "user", Kind: "text", Content: "ok", SizeBytes: 2},
+		},
+	}
+	policy := RedactionPolicyFunc(func(in FullyRenderedRequest) (FullyRenderedRequest, error) {
+		in.RegistrySnapshot = nil
+		in.RegistryReference = ""
+		in.TemplateVersion = ""
+		return in, nil
+	})
+
+	_, err := ApplyRedaction(content, policy)
+	if !errors.Is(err, ErrRedactionStructure) {
+		t.Fatalf("ApplyRedaction() error = %v, want ErrRedactionStructure", err)
+	}
+}
+
+func TestRedactionPolicy_CannotReplaceRegistrySnapshotWithoutStableReference(t *testing.T) {
+	content := FullyRenderedRequest{
+		TaskID:           "task-1",
+		SessionID:        "session-1",
+		RequestID:        "request-1",
+		WorkspaceID:      "workspace-1",
+		WorkspaceAlias:   "Alice",
+		AgentKey:         "agent-key",
+		RuntimeType:      "cli",
+		RuntimeKind:      "resumable_cli",
+		RegistrySnapshot: json.RawMessage(`{"partners":["Bob"]}`),
+		Inputs: []RenderedInputPart{
+			{Role: "user", Kind: "text", Content: "ok", SizeBytes: 2},
+		},
+	}
+	policy := RedactionPolicyFunc(func(in FullyRenderedRequest) (FullyRenderedRequest, error) {
+		in.RegistrySnapshot = json.RawMessage(`{}`)
+		return in, nil
+	})
+
+	_, err := ApplyRedaction(content, policy)
+	if !errors.Is(err, ErrRedactionStructure) {
+		t.Fatalf("ApplyRedaction() error = %v, want ErrRedactionStructure", err)
+	}
+}
+
+func TestRedactionPolicy_AllowsReplacingRegistrySnapshotWithStableReference(t *testing.T) {
+	content := FullyRenderedRequest{
+		TaskID:           "task-1",
+		SessionID:        "session-1",
+		RequestID:        "request-1",
+		WorkspaceID:      "workspace-1",
+		WorkspaceAlias:   "Alice",
+		AgentKey:         "agent-key",
+		RuntimeType:      "cli",
+		RuntimeKind:      "resumable_cli",
+		RegistrySnapshot: json.RawMessage(`{"partners":["Bob"]}`),
+		Inputs: []RenderedInputPart{
+			{Role: "user", Kind: "text", Content: "ok", SizeBytes: 2},
+		},
+	}
+	policy := RedactionPolicyFunc(func(in FullyRenderedRequest) (FullyRenderedRequest, error) {
+		in.RegistrySnapshot = nil
+		in.RegistryReference = "registry://stable"
+		in.TemplateVersion = "prompt-v2"
+		return in, nil
+	})
+
+	redacted, err := ApplyRedaction(content, policy)
+	if err != nil {
+		t.Fatalf("ApplyRedaction() error = %v", err)
+	}
+	if len(redacted.RegistrySnapshot) != 0 || redacted.RegistryReference != "registry://stable" || redacted.TemplateVersion != "prompt-v2" {
+		t.Fatalf("registry context = snapshot %s reference %q template %q, want stable replacement", redacted.RegistrySnapshot, redacted.RegistryReference, redacted.TemplateVersion)
+	}
+}
+
+func TestRedactionPolicy_CannotChangeExistingStableRegistryReference(t *testing.T) {
+	content := FullyRenderedRequest{
+		TaskID:            "task-1",
+		SessionID:         "session-1",
+		RequestID:         "request-1",
+		WorkspaceID:       "workspace-1",
+		WorkspaceAlias:    "Alice",
+		AgentKey:          "agent-key",
+		RuntimeType:       "cli",
+		RuntimeKind:       "resumable_cli",
+		RegistryReference: "registry://stable-v1",
+		TemplateVersion:   "prompt-v1",
+		Inputs: []RenderedInputPart{
+			{Role: "user", Kind: "text", Content: "ok", SizeBytes: 2},
+		},
+	}
+	policy := RedactionPolicyFunc(func(in FullyRenderedRequest) (FullyRenderedRequest, error) {
+		in.RegistryReference = "registry://stable-v2"
+		in.TemplateVersion = "prompt-v2"
+		return in, nil
+	})
+
+	_, err := ApplyRedaction(content, policy)
+	if !errors.Is(err, ErrRedactionStructure) {
+		t.Fatalf("ApplyRedaction() error = %v, want ErrRedactionStructure", err)
+	}
+}
+
 func TestRedactionPolicy_InPlaceMutationCannotCorruptStructuralMetadata(t *testing.T) {
 	content := FullyRenderedRequest{
 		TaskID:         "task-1",
@@ -372,8 +925,6 @@ func TestRedactionPolicy_InPlaceMutationCannotCorruptStructuralMetadata(t *testi
 		decision := typed[0]["decision"].(map[string][]string)
 		decision["sources"][0] = "wrong"
 		in.RegistrySnapshot = json.RawMessage(`{"partners":["Mallory"]}`)
-		in.RegistryReference = "registry://wrong"
-		in.TemplateVersion = "prompt-wrong"
 		in.Metadata["request"] = "wrong"
 		return in, nil
 	})
@@ -386,8 +937,8 @@ func TestRedactionPolicy_InPlaceMutationCannotCorruptStructuralMetadata(t *testi
 	if redacted.TaskID != "task-1" || redacted.Inputs[0].Role != "user" || redacted.Inputs[0].Kind != "text" || redacted.Inputs[0].ContentReference != "content://canonical" || redacted.Inputs[0].SizeBytes != 6 || redacted.Inputs[0].SourceReference != "message://source" {
 		t.Fatalf("redacted input structure = %#v, want original structural metadata restored", redacted)
 	}
-	if redacted.Inputs[0].Metadata["source"] != "user" {
-		t.Fatalf("redacted input metadata = %#v, want original metadata preserved", redacted.Inputs[0].Metadata)
+	if redacted.Inputs[0].Metadata["source"] != "wrong" {
+		t.Fatalf("redacted input metadata = %#v, want policy metadata preserved", redacted.Inputs[0].Metadata)
 	}
 	if redacted.Attachments[0].Kind != "file" || redacted.Attachments[0].Reference != "blob://secret" || redacted.Attachments[0].SizeBytes != 10 || redacted.Attachments[0].Digest != "sha256:secret" {
 		t.Fatalf("redacted attachment structure = %#v, want original structural metadata restored", redacted.Attachments[0])
@@ -396,7 +947,7 @@ func TestRedactionPolicy_InPlaceMutationCannotCorruptStructuralMetadata(t *testi
 	steps := nested["steps"].([]any)
 	typed := redacted.PromptDiagnostics["typed"].([]map[string]any)
 	decision := typed[0]["decision"].(map[string][]string)
-	if redacted.Attachments[0].Metadata["name"] != "secret.txt" || redacted.PromptDiagnostics["notes_included"] != false || steps[0] != "wrong" || decision["sources"][0] != "wrong" || string(redacted.RegistrySnapshot) != `{"partners":["Mallory"]}` || redacted.RegistryReference != "registry://snapshot-1" || redacted.TemplateVersion != "prompt-v1" || redacted.Metadata["request"] != "wrong" {
+	if redacted.Attachments[0].Metadata["name"] != "wrong" || redacted.PromptDiagnostics["notes_included"] != false || steps[0] != "wrong" || decision["sources"][0] != "wrong" || string(redacted.RegistrySnapshot) != `{"partners":["Mallory"]}` || redacted.RegistryReference != "registry://snapshot-1" || redacted.TemplateVersion != "prompt-v1" || redacted.Metadata["request"] != "wrong" {
 		t.Fatalf("redacted maps/references = input %#v attachment %#v diagnostics %#v snapshot %s reference %q template %q metadata %#v, want policy redactions plus replay references preserved", redacted.Inputs[0].Metadata, redacted.Attachments[0].Metadata, redacted.PromptDiagnostics, redacted.RegistrySnapshot, redacted.RegistryReference, redacted.TemplateVersion, redacted.Metadata)
 	}
 	originalNested := content.PromptDiagnostics["nested"].(map[string]any)
@@ -405,6 +956,369 @@ func TestRedactionPolicy_InPlaceMutationCannotCorruptStructuralMetadata(t *testi
 	originalDecision := originalTyped[0]["decision"].(map[string][]string)
 	if content.Inputs[0].Role != "user" || content.Inputs[0].ContentReference != "content://canonical" || content.Attachments[0].Digest != "sha256:secret" || originalSteps[0] != "registry" || originalDecision["sources"][0] != "registry" || string(content.RegistrySnapshot) != `{"partners":["Bob"]}` || content.RegistryReference != "registry://snapshot-1" || content.TemplateVersion != "prompt-v1" || content.Metadata["request"] != "root" {
 		t.Fatalf("original request mutated: %#v", content)
+	}
+}
+
+func TestRedactionPolicy_DiagnosticsJSONLikeMutationCannotMutateOriginalRequest(t *testing.T) {
+	content := FullyRenderedRequest{
+		TaskID:         "task-1",
+		SessionID:      "session-1",
+		RequestID:      "request-1",
+		WorkspaceID:    "workspace-1",
+		WorkspaceAlias: "Alice",
+		AgentKey:       "agent-key",
+		RuntimeType:    "cli",
+		RuntimeKind:    "resumable_cli",
+		Inputs: []RenderedInputPart{
+			{Role: "user", Kind: "text", Content: "ok", SizeBytes: 2},
+		},
+		PromptDiagnostics: map[string]any{
+			"map": map[string]any{
+				"items": []any{"original"},
+			},
+			"slice": []any{
+				map[string]string{"name": "original"},
+			},
+			"number": json.Number("12.5"),
+		},
+	}
+	policy := RedactionPolicyFunc(func(in FullyRenderedRequest) (FullyRenderedRequest, error) {
+		items := in.PromptDiagnostics["map"].(map[string]any)["items"].([]any)
+		items[0] = "redacted"
+
+		sliceEntry := in.PromptDiagnostics["slice"].([]any)[0].(map[string]string)
+		sliceEntry["name"] = "redacted"
+		return in, nil
+	})
+
+	_, err := ApplyRedaction(content, policy)
+	if err != nil {
+		t.Fatalf("ApplyRedaction() error = %v", err)
+	}
+
+	items := content.PromptDiagnostics["map"].(map[string]any)["items"].([]any)
+	sliceEntry := content.PromptDiagnostics["slice"].([]any)[0].(map[string]string)
+	if items[0] != "original" || sliceEntry["name"] != "original" {
+		t.Fatalf("original diagnostics mutated: %#v", content.PromptDiagnostics)
+	}
+}
+
+func TestRedactionPolicy_RejectsUnsupportedPromptDiagnosticsBeforePolicy(t *testing.T) {
+	content := FullyRenderedRequest{
+		TaskID:         "task-1",
+		SessionID:      "session-1",
+		RequestID:      "request-1",
+		WorkspaceID:    "workspace-1",
+		WorkspaceAlias: "Alice",
+		AgentKey:       "agent-key",
+		RuntimeType:    "cli",
+		RuntimeKind:    "resumable_cli",
+		Inputs: []RenderedInputPart{
+			{Role: "user", Kind: "text", Content: "ok", SizeBytes: 2},
+		},
+		PromptDiagnostics: map[string]any{
+			"ptr": &diagnosticValue{
+				Labels: []string{"original"},
+				Nested: &diagnosticNested{Value: "original"},
+			},
+		},
+	}
+	policyCalled := false
+	policy := RedactionPolicyFunc(func(in FullyRenderedRequest) (FullyRenderedRequest, error) {
+		policyCalled = true
+		return in, nil
+	})
+
+	_, err := ApplyRedaction(content, policy)
+	if !errors.Is(err, ErrRedactionStructure) {
+		t.Fatalf("ApplyRedaction() error = %v, want ErrRedactionStructure", err)
+	}
+	if policyCalled {
+		t.Fatal("policy was called for unsupported diagnostics")
+	}
+	ptr := content.PromptDiagnostics["ptr"].(*diagnosticValue)
+	if ptr.Labels[0] != "original" || ptr.Nested.Value != "original" {
+		t.Fatalf("original diagnostics mutated: %#v", content.PromptDiagnostics)
+	}
+}
+
+func TestRedactionPolicy_RejectsUnsupportedPromptDiagnosticsShapes(t *testing.T) {
+	sliceCycle := []any{nil}
+	sliceCycle[0] = sliceCycle
+	mapCycle := map[string]any{}
+	mapCycle["self"] = mapCycle
+
+	tests := []struct {
+		name  string
+		value any
+	}{
+		{name: "struct", value: diagnosticValue{Labels: []string{"original"}}},
+		{name: "non_string_map_key", value: map[int]string{1: "original"}},
+		{name: "slice_cycle", value: sliceCycle},
+		{name: "map_cycle", value: mapCycle},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content := FullyRenderedRequest{
+				TaskID:         "task-1",
+				SessionID:      "session-1",
+				RequestID:      "request-1",
+				WorkspaceID:    "workspace-1",
+				WorkspaceAlias: "Alice",
+				AgentKey:       "agent-key",
+				RuntimeType:    "cli",
+				RuntimeKind:    "resumable_cli",
+				Inputs: []RenderedInputPart{
+					{Role: "user", Kind: "text", Content: "ok", SizeBytes: 2},
+				},
+				PromptDiagnostics: map[string]any{
+					"bad": tt.value,
+				},
+			}
+			policyCalled := false
+			policy := RedactionPolicyFunc(func(in FullyRenderedRequest) (FullyRenderedRequest, error) {
+				policyCalled = true
+				return in, nil
+			})
+
+			_, err := ApplyRedaction(content, policy)
+			if !errors.Is(err, ErrRedactionStructure) {
+				t.Fatalf("ApplyRedaction() error = %v, want ErrRedactionStructure", err)
+			}
+			if policyCalled {
+				t.Fatal("policy was called for unsupported diagnostics")
+			}
+		})
+	}
+}
+
+func TestRedactionPolicy_RejectsNonFinitePromptDiagnosticsFloats(t *testing.T) {
+	tests := []struct {
+		name  string
+		value any
+	}{
+		{name: "float64_nan", value: math.NaN()},
+		{name: "float64_inf", value: math.Inf(1)},
+		{name: "float32_inf", value: float32(math.Inf(-1))},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content := FullyRenderedRequest{
+				TaskID:         "task-1",
+				SessionID:      "session-1",
+				RequestID:      "request-1",
+				WorkspaceID:    "workspace-1",
+				WorkspaceAlias: "Alice",
+				AgentKey:       "agent-key",
+				RuntimeType:    "cli",
+				RuntimeKind:    "resumable_cli",
+				Inputs: []RenderedInputPart{
+					{Role: "user", Kind: "text", Content: "ok", SizeBytes: 2},
+				},
+				PromptDiagnostics: map[string]any{
+					"bad": tt.value,
+				},
+			}
+			policyCalled := false
+			policy := RedactionPolicyFunc(func(in FullyRenderedRequest) (FullyRenderedRequest, error) {
+				policyCalled = true
+				return in, nil
+			})
+
+			_, err := ApplyRedaction(content, policy)
+			if !errors.Is(err, ErrRedactionStructure) {
+				t.Fatalf("ApplyRedaction() error = %v, want ErrRedactionStructure", err)
+			}
+			if policyCalled {
+				t.Fatal("policy was called for non-finite diagnostics")
+			}
+		})
+	}
+}
+
+func TestRedactionPolicy_RejectsInvalidJSONNumbersBeforePolicy(t *testing.T) {
+	tests := []struct {
+		name  string
+		value any
+	}{
+		{name: "nan", value: json.Number("NaN")},
+		{name: "infinity", value: json.Number("Infinity")},
+		{name: "empty", value: json.Number("")},
+		{name: "nested_slice_nan", value: []json.Number{json.Number("NaN")}},
+		{name: "nested_map_infinity", value: map[string]json.Number{"bad": json.Number("Infinity")}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content := FullyRenderedRequest{
+				TaskID:         "task-1",
+				SessionID:      "session-1",
+				RequestID:      "request-1",
+				WorkspaceID:    "workspace-1",
+				WorkspaceAlias: "Alice",
+				AgentKey:       "agent-key",
+				RuntimeType:    "cli",
+				RuntimeKind:    "resumable_cli",
+				Inputs: []RenderedInputPart{
+					{Role: "user", Kind: "text", Content: "ok", SizeBytes: 2},
+				},
+				PromptDiagnostics: map[string]any{
+					"bad": tt.value,
+				},
+			}
+			policyCalled := false
+			policy := RedactionPolicyFunc(func(in FullyRenderedRequest) (FullyRenderedRequest, error) {
+				policyCalled = true
+				return in, nil
+			})
+
+			_, err := ApplyRedaction(content, policy)
+			if !errors.Is(err, ErrRedactionStructure) {
+				t.Fatalf("ApplyRedaction() error = %v, want ErrRedactionStructure", err)
+			}
+			if policyCalled {
+				t.Fatal("policy was called for invalid json.Number diagnostics")
+			}
+		})
+	}
+}
+
+func TestApplyRedaction_NilPolicyRejectsInvalidJSONNumberDiagnostics(t *testing.T) {
+	tests := []struct {
+		name  string
+		value json.Number
+	}{
+		{name: "nan", value: json.Number("NaN")},
+		{name: "infinity", value: json.Number("Infinity")},
+		{name: "empty", value: json.Number("")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content := FullyRenderedRequest{
+				TaskID:         "task-1",
+				SessionID:      "session-1",
+				RequestID:      "request-1",
+				WorkspaceID:    "workspace-1",
+				WorkspaceAlias: "Alice",
+				AgentKey:       "agent-key",
+				RuntimeType:    "cli",
+				RuntimeKind:    "resumable_cli",
+				Inputs: []RenderedInputPart{
+					{Role: "user", Kind: "text", Content: "ok", SizeBytes: 2},
+				},
+				PromptDiagnostics: map[string]any{
+					"bad": tt.value,
+				},
+			}
+
+			_, err := ApplyRedaction(content, nil)
+			if !errors.Is(err, ErrRedactionStructure) {
+				t.Fatalf("ApplyRedaction() error = %v, want ErrRedactionStructure", err)
+			}
+		})
+	}
+}
+
+func TestApplyRedaction_NilPolicyRejectsNestedInvalidJSONNumberDiagnostics(t *testing.T) {
+	content := FullyRenderedRequest{
+		TaskID:         "task-1",
+		SessionID:      "session-1",
+		RequestID:      "request-1",
+		WorkspaceID:    "workspace-1",
+		WorkspaceAlias: "Alice",
+		AgentKey:       "agent-key",
+		RuntimeType:    "cli",
+		RuntimeKind:    "resumable_cli",
+		Inputs: []RenderedInputPart{
+			{Role: "user", Kind: "text", Content: "ok", SizeBytes: 2},
+		},
+		PromptDiagnostics: map[string]any{
+			"nested": map[string]any{
+				"bad": []json.Number{json.Number("Infinity")},
+			},
+		},
+	}
+
+	_, err := ApplyRedaction(content, nil)
+	if !errors.Is(err, ErrRedactionStructure) {
+		t.Fatalf("ApplyRedaction() error = %v, want ErrRedactionStructure", err)
+	}
+}
+
+func TestApplyRedaction_NilPolicyReturnsValidatedCloneWithValidJSONNumber(t *testing.T) {
+	content := FullyRenderedRequest{
+		TaskID:         "task-1",
+		SessionID:      "session-1",
+		RequestID:      "request-1",
+		WorkspaceID:    "workspace-1",
+		WorkspaceAlias: "Alice",
+		AgentKey:       "agent-key",
+		RuntimeType:    "cli",
+		RuntimeKind:    "resumable_cli",
+		Inputs: []RenderedInputPart{
+			{Role: "user", Kind: "text", Content: "ok", SizeBytes: 2},
+		},
+		PromptDiagnostics: map[string]any{
+			"number": json.Number("12.5"),
+			"nested": map[string]any{
+				"items": []any{"original"},
+			},
+		},
+	}
+
+	redacted, err := ApplyRedaction(content, nil)
+	if err != nil {
+		t.Fatalf("ApplyRedaction() error = %v", err)
+	}
+	if got := redacted.PromptDiagnostics["number"]; got != json.Number("12.5") {
+		t.Fatalf("PromptDiagnostics[number] = %#v, want json.Number(%q)", got, "12.5")
+	}
+
+	redactedNested := redacted.PromptDiagnostics["nested"].(map[string]any)
+	redactedItems := redactedNested["items"].([]any)
+	redactedItems[0] = "mutated"
+	redacted.PromptDiagnostics["number"] = json.Number("7")
+
+	originalNested := content.PromptDiagnostics["nested"].(map[string]any)
+	originalItems := originalNested["items"].([]any)
+	if originalItems[0] != "original" || content.PromptDiagnostics["number"] != json.Number("12.5") {
+		t.Fatalf("original diagnostics mutated: %#v", content.PromptDiagnostics)
+	}
+}
+
+func TestRedactionPolicy_RejectsUnsupportedPromptDiagnosticsReturnedByPolicy(t *testing.T) {
+	content := FullyRenderedRequest{
+		TaskID:         "task-1",
+		SessionID:      "session-1",
+		RequestID:      "request-1",
+		WorkspaceID:    "workspace-1",
+		WorkspaceAlias: "Alice",
+		AgentKey:       "agent-key",
+		RuntimeType:    "cli",
+		RuntimeKind:    "resumable_cli",
+		Inputs: []RenderedInputPart{
+			{Role: "user", Kind: "text", Content: "ok", SizeBytes: 2},
+		},
+		PromptDiagnostics: map[string]any{
+			"ok": []any{"original"},
+		},
+	}
+	policyCalled := false
+	policy := RedactionPolicyFunc(func(in FullyRenderedRequest) (FullyRenderedRequest, error) {
+		policyCalled = true
+		in.PromptDiagnostics["bad"] = func() {}
+		return in, nil
+	})
+
+	_, err := ApplyRedaction(content, policy)
+	if !errors.Is(err, ErrRedactionStructure) {
+		t.Fatalf("ApplyRedaction() error = %v, want ErrRedactionStructure", err)
+	}
+	if !policyCalled {
+		t.Fatal("policy was not called")
 	}
 }
 
@@ -449,6 +1363,69 @@ func TestMemorySink_CloseRejectsWrites(t *testing.T) {
 	}
 }
 
+func TestMemorySink_CloseRejectsTranscriptWrites(t *testing.T) {
+	ctx := context.Background()
+	sink := NewMemorySink()
+	if err := sink.Close(ctx); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	err := sink.WriteTranscript(ctx, NewOutputTranscript("task-1", "session-1", "request-1", "output", 1, time.Now()))
+	if !errors.Is(err, ErrSinkClosed) {
+		t.Fatalf("WriteTranscript() error = %v, want ErrSinkClosed", err)
+	}
+}
+
+func TestMemorySink_CanceledContextRejectsWriteAndClose(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	sink := NewMemorySink()
+
+	eventErr := sink.WriteEvent(ctx, testEvent("task-1", EventTypeTaskCreated, 1))
+	if !errors.Is(eventErr, context.Canceled) {
+		t.Fatalf("WriteEvent() error = %v, want context.Canceled", eventErr)
+	}
+	transcriptErr := sink.WriteTranscript(ctx, NewOutputTranscript("task-1", "session-1", "request-1", "output", 1, time.Now()))
+	if !errors.Is(transcriptErr, context.Canceled) {
+		t.Fatalf("WriteTranscript() error = %v, want context.Canceled", transcriptErr)
+	}
+	closeErr := sink.Close(ctx)
+	if !errors.Is(closeErr, context.Canceled) {
+		t.Fatalf("Close() error = %v, want context.Canceled", closeErr)
+	}
+}
+
+func TestMemorySink_AccessorsReturnIsolatedRecordContent(t *testing.T) {
+	ctx := context.Background()
+	sink := NewMemorySink()
+	event := testEvent("task-1", EventTypeTaskCreated, 1)
+	transcript := NewOutputTranscript("task-1", "session-1", "request-1", "output", 1, time.Now())
+
+	if err := sink.WriteEvent(ctx, event); err != nil {
+		t.Fatalf("WriteEvent() error = %v", err)
+	}
+	if err := sink.WriteTranscript(ctx, transcript); err != nil {
+		t.Fatalf("WriteTranscript() error = %v", err)
+	}
+
+	event.Payload[0] = '['
+	transcript.Content[0] = 'X'
+
+	events := sink.Events("task-1")
+	transcripts := sink.Transcripts("task-1")
+	events[0].Payload[0] = '['
+	transcripts[0].Content[0] = 'X'
+
+	events = sink.Events("task-1")
+	transcripts = sink.Transcripts("task-1")
+	if string(events[0].Payload) != `{"ok":true}` {
+		t.Fatalf("stored event payload = %s, want original JSON", events[0].Payload)
+	}
+	if string(transcripts[0].Content) != "output" {
+		t.Fatalf("stored transcript content = %q, want output", transcripts[0].Content)
+	}
+}
+
 func testEvent(taskID idgen.TaskID, typ EventType, seq uint64) EventRecord {
 	return EventRecord{
 		EventID:    fmt.Sprintf("event-%d", seq),
@@ -469,6 +1446,7 @@ type stubSink struct {
 	closeErr             error
 	writeEventCalls      int
 	writeTranscriptCalls int
+	closeCalls           int
 }
 
 func (s *stubSink) WriteEvent(ctx context.Context, record EventRecord) error {
@@ -482,5 +1460,113 @@ func (s *stubSink) WriteTranscript(ctx context.Context, record TranscriptRecord)
 }
 
 func (s *stubSink) Close(ctx context.Context) error {
+	s.closeCalls++
+	if err := ctx.Err(); err != nil && s.closeErr == nil {
+		return err
+	}
 	return s.closeErr
+}
+
+type blockingFanoutSink struct {
+	mu                sync.Mutex
+	firstCallStarted  chan struct{}
+	secondCallStarted chan struct{}
+	releaseFirst      chan struct{}
+	calls             int
+}
+
+func newBlockingFanoutSink() *blockingFanoutSink {
+	return &blockingFanoutSink{
+		firstCallStarted:  make(chan struct{}),
+		secondCallStarted: make(chan struct{}),
+		releaseFirst:      make(chan struct{}),
+	}
+}
+
+func (s *blockingFanoutSink) WriteEvent(ctx context.Context, record EventRecord) error {
+	s.mu.Lock()
+	s.calls++
+	call := s.calls
+	if call == 1 {
+		close(s.firstCallStarted)
+	}
+	if call == 2 {
+		close(s.secondCallStarted)
+	}
+	s.mu.Unlock()
+
+	if call == 1 {
+		select {
+		case <-s.releaseFirst:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return nil
+}
+
+func (s *blockingFanoutSink) WriteTranscript(ctx context.Context, record TranscriptRecord) error {
+	return nil
+}
+
+func (s *blockingFanoutSink) Close(ctx context.Context) error {
+	return nil
+}
+
+func (s *blockingFanoutSink) waitForFirstCall() error {
+	select {
+	case <-s.firstCallStarted:
+		return nil
+	case <-time.After(time.Second):
+		return errors.New("timed out waiting for first write to reach first sink")
+	}
+}
+
+func (s *blockingFanoutSink) callCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+func (s *blockingFanoutSink) releaseFirstCall() {
+	close(s.releaseFirst)
+}
+
+type recordingSink struct {
+	mu     sync.Mutex
+	events []EventRecord
+}
+
+func (s *recordingSink) WriteEvent(ctx context.Context, record EventRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, cloneEventRecord(record))
+	return nil
+}
+
+func (s *recordingSink) WriteTranscript(ctx context.Context, record TranscriptRecord) error {
+	return nil
+}
+
+func (s *recordingSink) Close(ctx context.Context) error {
+	return nil
+}
+
+func (s *recordingSink) eventSeqs() []uint64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	seqs := make([]uint64, len(s.events))
+	for i, event := range s.events {
+		seqs[i] = event.Seq
+	}
+	return seqs
+}
+
+type diagnosticValue struct {
+	Labels []string
+	Nested *diagnosticNested
+}
+
+type diagnosticNested struct {
+	Value string
 }

--- a/pkg/orchestrator/events/PLAN.md
+++ b/pkg/orchestrator/events/PLAN.md
@@ -43,9 +43,18 @@ the engine or invoker, and it drops events under back-pressure.
 - `Publish` enqueues the event to every active subscriber for the given
   `task_id` whose optional `session_id` and `request_id` filters also
   match.
+- Delivery/drop accounting is serialized with the bus subscriber map so a
+  later accepted `Publish` cannot enqueue ahead of an earlier accepted
+  `Publish`.
+- For JSON-like payloads, the bus snapshots mutable values before enqueue.
+  Each subscriber receives its own copy of supported mutable payload shapes:
+  primitives, `json.Number`, `[]byte`, arrays/slices, and maps with string
+  keys. Other payload values are treated as immutable by contract; publishers
+  must not mutate them after calling `Publish`.
 - For each subscriber, if its channel buffer is full, the event is
   dropped for that subscriber and the dropped counter is incremented.
-- `Publish` never blocks. The engine and invoker rely on this property.
+- `Publish` never waits for subscriber reads or external I/O. The engine and
+  invoker rely on this best-effort property.
 
 ### Subscribe path
 
@@ -89,6 +98,9 @@ the engine or invoker, and it drops events under back-pressure.
 - The bus tracks subscribers under a mutex keyed by `(TaskID,
   subscriberID)`. Subscription close is idempotent and safe to race with
   publish.
+- Publishers may race safely; the bus serializes enqueue attempts and gives
+  every subscriber a stable per-publish payload snapshot for supported
+  JSON-like payloads.
 
 ## Edge cases & decisions
 

--- a/pkg/orchestrator/events/PLAN.md
+++ b/pkg/orchestrator/events/PLAN.md
@@ -62,6 +62,13 @@ the engine or invoker, and it drops events under back-pressure.
 - `Bus.Close` notifies all subscribers (closes their `Events()` channels)
   and drains in-flight publishes. After `Close`, further `Publish` calls
   return zero counts; further `Subscribe` calls return `ErrBusClosed`.
+- Close first gates the bus under the subscriber map mutex so no new publish
+  can take a subscriber snapshot, then waits for publishes that already took
+  a snapshot to finish delivery/drop accounting before closing subscriber
+  channels. If the caller's context is already canceled, the same local close
+  sequence still runs and `Close` returns the context error afterward.
+  Concurrent and repeated callers wait for that close sequence to finish
+  before returning their own context result.
 
 ## Drop policy
 
@@ -89,10 +96,17 @@ the engine or invoker, and it drops events under back-pressure.
   drop counter. Drops are independent.
 - Subscribing after the task ended: returns `ErrSubscribeUnknownTask`. The
   caller can fall back to `Wait` for the final result.
+- Subscribe validates `TaskID` before consulting `ctx`, and a closed bus
+  returns `ErrBusClosed` even when the caller's context is canceled. On an
+  active bus with a valid task id, a canceled context returns the context
+  error.
 - Publishing with `task_id == ""`: the bus ignores the publish (zero
   delivered, zero dropped). The `Bus.Publish` signature has no error
   return because publishers are best-effort; callers MUST validate
-  `task_id` before invoking. Same for an already-cancelled `ctx`.
+  `task_id` before invoking.
+- Publishing with an already-canceled `ctx` suppresses non-terminal events.
+  Terminal task events still mark the task terminal, attempt delivery/drop
+  accounting, and close subscribers.
 - Engine shutdown: `Bus.Close` is called by the orchestrator's shutdown
   path; existing subscribers see channel close.
 

--- a/pkg/orchestrator/events/PLAN.md
+++ b/pkg/orchestrator/events/PLAN.md
@@ -17,10 +17,15 @@ the engine or invoker, and it drops events under back-pressure.
 - `Subscription` interface:
   - `Events() <-chan Event`
   - `Errors() <-chan error` — surface non-fatal subscriber issues
+  - `Dropped() uint64` — cumulative count of events dropped for this subscriber
   - `Close() error`
 - `SubscribeOptions`:
   - `TaskID TaskID` — required; subscribers always scope to one task in
     v1. (Cross-task subscriptions are a v2 extension.)
+  - `SessionID SessionID` — optional; when set, only matching session
+    events are delivered.
+  - `RequestID RequestID` — optional; when set, only matching request
+    events are delivered. This is normally paired with `SessionID`.
   - `BufferSize int` — per-subscriber channel size; defaults to 256.
   - `IncludeChunks bool` — if false (default), `request.text_chunk` is
     suppressed; useful for slow consumers.
@@ -36,7 +41,8 @@ the engine or invoker, and it drops events under back-pressure.
 - The caller of `Publish` is the owning component after a successful
   `audit.Sink.WriteEvent`. `Publish` does not write audit records itself.
 - `Publish` enqueues the event to every active subscriber for the given
-  `task_id` (subscribers scoped to a different task ignore the publish).
+  `task_id` whose optional `session_id` and `request_id` filters also
+  match.
 - For each subscriber, if its channel buffer is full, the event is
   dropped for that subscriber and the dropped counter is incremented.
 - `Publish` never blocks. The engine and invoker rely on this property.
@@ -61,17 +67,21 @@ the engine or invoker, and it drops events under back-pressure.
 
 - v1 uses pure non-blocking buffered channels per subscriber. No coalescing
   of chunk events.
-- Dropped counts are published on `Errors()` periodically (e.g., every 1
-  second per subscriber) so consumers know they fell behind.
+- A drop produces a `SubscriberLaggedError` pushed inline onto the
+  subscriber's `Errors()` channel. When that channel (buffer size 1) is
+  full, the bus drops the older notification and replaces it with the
+  newer one — consumers always see the latest cumulative `Dropped()`
+  count, never a stale one. They may miss intermediate counts.
 - The bus does not implement backoff or rate limiting in v1.
 
 ## Subscriber concurrency
 
-- Each subscriber runs in its own goroutine started by `Subscribe`.
-- The goroutine forwards events from the bus's internal queue to the
-  subscriber's channel. On subscriber close, it drains and exits.
-- The bus tracks subscribers under an `sync.Map` keyed by `(TaskID,
-  subscriberID)`.
+- Each subscriber owns a bounded event channel. `Publish` uses
+  non-blocking sends to those channels and never waits for consumers to
+  read.
+- The bus tracks subscribers under a mutex keyed by `(TaskID,
+  subscriberID)`. Subscription close is idempotent and safe to race with
+  publish.
 
 ## Edge cases & decisions
 
@@ -79,19 +89,22 @@ the engine or invoker, and it drops events under back-pressure.
   drop counter. Drops are independent.
 - Subscribing after the task ended: returns `ErrSubscribeUnknownTask`. The
   caller can fall back to `Wait` for the final result.
-- Publishing with `task_id == ""`: the bus rejects the publish. All
-  events must be task-scoped.
+- Publishing with `task_id == ""`: the bus ignores the publish (zero
+  delivered, zero dropped). The `Bus.Publish` signature has no error
+  return because publishers are best-effort; callers MUST validate
+  `task_id` before invoking. Same for an already-cancelled `ctx`.
 - Engine shutdown: `Bus.Close` is called by the orchestrator's shutdown
   path; existing subscribers see channel close.
 
-## Tests to write (no implementation in this pass)
+## Tests
 
 1. Subscribe → Publish → Events delivered in order.
 2. Slow subscriber drops events, fast subscriber does not.
 3. `IncludeChunks = false` filters out `request.text_chunk` events.
 4. Task terminal closes subscriber channel.
 5. Subscribe after terminal returns `ErrSubscribeUnknownTask`.
-6. Concurrent publishers and subscribers under `-race`.
+6. Session/request scoped subscribers receive only matching events.
+7. Concurrent publishers and subscribers under `-race`.
 
 ## Out of scope
 

--- a/pkg/orchestrator/events/events.go
+++ b/pkg/orchestrator/events/events.go
@@ -3,8 +3,10 @@ package events
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -126,6 +128,10 @@ func (b *inProcessBus) Publish(ctx context.Context, event Event) (int, int) {
 		return 0, 0
 	}
 	b.activePublishes.Add(1)
+	defer func() {
+		b.activePublishes.Done()
+		b.mu.Unlock()
+	}()
 	taskSubscribers := b.subscribers[event.TaskID]
 	matchedSubscribers := make([]*subscription, 0, len(taskSubscribers))
 	taskSubscribersAll := make([]*subscription, 0, len(taskSubscribers))
@@ -139,13 +145,11 @@ func (b *inProcessBus) Publish(ctx context.Context, event Event) (int, int) {
 		b.terminal[event.TaskID] = struct{}{}
 		delete(b.subscribers, event.TaskID)
 	}
-	b.mu.Unlock()
-	defer b.activePublishes.Done()
 
 	delivered := 0
 	dropped := 0
 	for _, sub := range matchedSubscribers {
-		switch sub.publish(event) {
+		switch sub.publish(snapshotEventPayload(event)) {
 		case publishDelivered:
 			delivered++
 		case publishDropped:
@@ -159,6 +163,112 @@ func (b *inProcessBus) Publish(ctx context.Context, event Event) (int, int) {
 		}
 	}
 	return delivered, dropped
+}
+
+func snapshotEventPayload(event Event) Event {
+	event.Payload = cloneEventPayload(event.Payload)
+	return event
+}
+
+type payloadVisit struct {
+	typ reflect.Type
+	ptr uintptr
+}
+
+var jsonNumberType = reflect.TypeOf(json.Number(""))
+
+func cloneEventPayload(payload any) any {
+	if payload == nil {
+		return nil
+	}
+	return clonePayloadValue(reflect.ValueOf(payload), make(map[payloadVisit]struct{})).Interface()
+}
+
+func clonePayloadValue(value reflect.Value, active map[payloadVisit]struct{}) reflect.Value {
+	if !value.IsValid() {
+		return value
+	}
+	if value.Type() == jsonNumberType {
+		return value
+	}
+
+	switch value.Kind() {
+	case reflect.Interface:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		cloned := clonePayloadValue(value.Elem(), active)
+		wrapped := reflect.New(value.Type()).Elem()
+		wrapped.Set(compatiblePayloadValue(cloned, value.Type(), value.Elem()))
+		return wrapped
+	case reflect.Map:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		if value.Type().Key().Kind() != reflect.String {
+			return value
+		}
+		visit := payloadVisit{typ: value.Type(), ptr: value.Pointer()}
+		if _, ok := active[visit]; ok {
+			return value
+		}
+		active[visit] = struct{}{}
+		defer delete(active, visit)
+
+		cloned := reflect.MakeMapWithSize(value.Type(), value.Len())
+		iter := value.MapRange()
+		for iter.Next() {
+			clonedValue := clonePayloadValue(iter.Value(), active)
+			cloned.SetMapIndex(iter.Key(), compatiblePayloadValue(clonedValue, value.Type().Elem(), iter.Value()))
+		}
+		return cloned
+	case reflect.Slice:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		visit := payloadVisit{typ: value.Type(), ptr: value.Pointer()}
+		if visit.ptr != 0 {
+			if _, ok := active[visit]; ok {
+				return value
+			}
+			active[visit] = struct{}{}
+			defer delete(active, visit)
+		}
+
+		cloned := reflect.MakeSlice(value.Type(), value.Len(), value.Len())
+		for i := range value.Len() {
+			clonedValue := clonePayloadValue(value.Index(i), active)
+			cloned.Index(i).Set(compatiblePayloadValue(clonedValue, value.Type().Elem(), value.Index(i)))
+		}
+		return cloned
+	case reflect.Array:
+		cloned := reflect.New(value.Type()).Elem()
+		for i := range value.Len() {
+			clonedValue := clonePayloadValue(value.Index(i), active)
+			cloned.Index(i).Set(compatiblePayloadValue(clonedValue, value.Type().Elem(), value.Index(i)))
+		}
+		return cloned
+	case reflect.Bool, reflect.String,
+		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64:
+		return value
+	default:
+		return value
+	}
+}
+
+func compatiblePayloadValue(value reflect.Value, target reflect.Type, fallback reflect.Value) reflect.Value {
+	if !value.IsValid() {
+		return fallback
+	}
+	if value.Type().AssignableTo(target) {
+		return value
+	}
+	if value.Type().ConvertibleTo(target) {
+		return value.Convert(target)
+	}
+	return fallback
 }
 
 func (b *inProcessBus) Subscribe(ctx context.Context, options SubscribeOptions) (Subscription, error) {

--- a/pkg/orchestrator/events/events.go
+++ b/pkg/orchestrator/events/events.go
@@ -94,22 +94,29 @@ func (e *SubscriberLaggedError) Unwrap() error {
 }
 
 type inProcessBus struct {
-	mu          sync.Mutex
-	closed      bool
-	nextSubID   uint64
-	subscribers map[idgen.TaskID]map[uint64]*subscription
-	terminal    map[idgen.TaskID]struct{}
+	mu              sync.Mutex
+	closed          bool
+	closeDone       chan struct{}
+	activePublishes sync.WaitGroup
+	nextSubID       uint64
+	subscribers     map[idgen.TaskID]map[uint64]*subscription
+	terminal        map[idgen.TaskID]struct{}
 }
 
 func NewBus() Bus {
 	return &inProcessBus{
+		closeDone:   make(chan struct{}),
 		subscribers: make(map[idgen.TaskID]map[uint64]*subscription),
 		terminal:    make(map[idgen.TaskID]struct{}),
 	}
 }
 
 func (b *inProcessBus) Publish(ctx context.Context, event Event) (int, int) {
-	if ctx.Err() != nil || event.TaskID == "" {
+	if event.TaskID == "" {
+		return 0, 0
+	}
+	terminal := isTerminalTaskEvent(event.Type)
+	if ctx.Err() != nil && !terminal {
 		return 0, 0
 	}
 
@@ -118,6 +125,7 @@ func (b *inProcessBus) Publish(ctx context.Context, event Event) (int, int) {
 		b.mu.Unlock()
 		return 0, 0
 	}
+	b.activePublishes.Add(1)
 	taskSubscribers := b.subscribers[event.TaskID]
 	matchedSubscribers := make([]*subscription, 0, len(taskSubscribers))
 	taskSubscribersAll := make([]*subscription, 0, len(taskSubscribers))
@@ -127,19 +135,20 @@ func (b *inProcessBus) Publish(ctx context.Context, event Event) (int, int) {
 			matchedSubscribers = append(matchedSubscribers, sub)
 		}
 	}
-	terminal := isTerminalTaskEvent(event.Type)
 	if terminal {
 		b.terminal[event.TaskID] = struct{}{}
 		delete(b.subscribers, event.TaskID)
 	}
 	b.mu.Unlock()
+	defer b.activePublishes.Done()
 
 	delivered := 0
 	dropped := 0
 	for _, sub := range matchedSubscribers {
-		if sub.publish(event) {
+		switch sub.publish(event) {
+		case publishDelivered:
 			delivered++
-		} else {
+		case publishDropped:
 			dropped++
 		}
 	}
@@ -153,9 +162,6 @@ func (b *inProcessBus) Publish(ctx context.Context, event Event) (int, int) {
 }
 
 func (b *inProcessBus) Subscribe(ctx context.Context, options SubscribeOptions) (Subscription, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, fmt.Errorf("subscribe task %q: %w", options.TaskID, err)
-	}
 	if options.TaskID == "" {
 		return nil, fmt.Errorf("subscribe task: %w", ErrSubscribeUnknownTask)
 	}
@@ -171,6 +177,9 @@ func (b *inProcessBus) Subscribe(ctx context.Context, options SubscribeOptions) 
 	if _, ended := b.terminal[options.TaskID]; ended {
 		return nil, fmt.Errorf("subscribe task %q: %w", options.TaskID, ErrSubscribeUnknownTask)
 	}
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("subscribe task %q: %w", options.TaskID, err)
+	}
 
 	b.nextSubID++
 	sub := newSubscription(b, b.nextSubID, options)
@@ -182,13 +191,14 @@ func (b *inProcessBus) Subscribe(ctx context.Context, options SubscribeOptions) 
 }
 
 func (b *inProcessBus) Close(ctx context.Context) error {
-	if err := ctx.Err(); err != nil {
-		return fmt.Errorf("close event bus: %w", err)
-	}
-
 	b.mu.Lock()
 	if b.closed {
+		closeDone := b.closeDone
 		b.mu.Unlock()
+		<-closeDone
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("close event bus: %w", err)
+		}
 		return nil
 	}
 	b.closed = true
@@ -199,10 +209,16 @@ func (b *inProcessBus) Close(ctx context.Context) error {
 		}
 	}
 	b.subscribers = make(map[idgen.TaskID]map[uint64]*subscription)
+	closeDone := b.closeDone
 	b.mu.Unlock()
 
+	b.activePublishes.Wait()
 	for _, sub := range subscribers {
 		sub.close()
+	}
+	close(closeDone)
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("close event bus: %w", err)
 	}
 	return nil
 }
@@ -286,15 +302,23 @@ func (s *subscription) matches(event Event) bool {
 	return true
 }
 
-func (s *subscription) publish(event Event) bool {
+type publishStatus int
+
+const (
+	publishInactive publishStatus = iota
+	publishDelivered
+	publishDropped
+)
+
+func (s *subscription) publish(event Event) publishStatus {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.closed {
-		return false
+		return publishInactive
 	}
 	select {
 	case s.events <- event:
-		return true
+		return publishDelivered
 	default:
 		dropped := s.dropped.Add(1)
 		err := &SubscriberLaggedError{
@@ -318,7 +342,7 @@ func (s *subscription) publish(event Event) bool {
 			default:
 			}
 		}
-		return false
+		return publishDropped
 	}
 }
 

--- a/pkg/orchestrator/events/events.go
+++ b/pkg/orchestrator/events/events.go
@@ -1,0 +1,332 @@
+// Package events provides the orchestrator's in-process best-effort event bus.
+package events
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/AiRanthem/ANA/pkg/orchestrator/idgen"
+)
+
+var (
+	ErrBusClosed            = errors.New("event bus closed")
+	ErrSubscribeUnknownTask = errors.New("subscribe unknown task")
+	ErrSubscriberLagged     = errors.New("subscriber lagged")
+)
+
+// EventType enumerates the runtime bus event taxonomy. The values MUST stay
+// in lockstep with audit.EventType in pkg/orchestrator/audit/audit.go —
+// AGENTS.md forbids cross-imports between events and audit, so updates here
+// require a matching edit in audit.go.
+type EventType string
+
+const (
+	EventTypeTaskCreated      EventType = "task.created"
+	EventTypeTaskRunning      EventType = "task.running"
+	EventTypeTaskCompleted    EventType = "task.completed"
+	EventTypeTaskFailed       EventType = "task.failed"
+	EventTypeTaskCancelled    EventType = "task.cancelled"
+	EventTypeSessionOpened    EventType = "session.opened"
+	EventTypeSessionPaused    EventType = "session.paused"
+	EventTypeSessionResumed   EventType = "session.resumed"
+	EventTypeSessionClosed    EventType = "session.closed"
+	EventTypeSessionFailed    EventType = "session.failed"
+	EventTypeRequestCreated   EventType = "request.created"
+	EventTypeRequestRunning   EventType = "request.running"
+	EventTypeRequestCompleted EventType = "request.completed"
+	EventTypeRequestFailed    EventType = "request.failed"
+	EventTypeRequestTextChunk EventType = "request.text_chunk"
+	EventTypeRouteDirective   EventType = "route.directive"
+)
+
+type Event struct {
+	EventID    string
+	TaskID     idgen.TaskID
+	SessionID  idgen.SessionID
+	RequestID  idgen.RequestID
+	Type       EventType
+	Seq        uint64
+	OccurredAt time.Time
+	Payload    any
+}
+
+type Bus interface {
+	Publish(ctx context.Context, event Event) (delivered int, dropped int)
+	Subscribe(ctx context.Context, options SubscribeOptions) (Subscription, error)
+	Close(ctx context.Context) error
+}
+
+type SubscribeOptions struct {
+	TaskID        idgen.TaskID
+	SessionID     idgen.SessionID
+	RequestID     idgen.RequestID
+	BufferSize    int
+	IncludeChunks bool
+}
+
+type Subscription interface {
+	Events() <-chan Event
+	Errors() <-chan error
+	Dropped() uint64
+	Close() error
+}
+
+type SubscriberLaggedError struct {
+	TaskID     idgen.TaskID
+	SessionID  idgen.SessionID
+	RequestID  idgen.RequestID
+	EventType  EventType
+	EventSeq   uint64
+	Dropped    uint64
+	Subscriber string
+}
+
+func (e *SubscriberLaggedError) Error() string {
+	return fmt.Sprintf("subscriber %s lagged for task %q event %q seq %d: dropped %d: %v", e.Subscriber, e.TaskID, e.EventType, e.EventSeq, e.Dropped, ErrSubscriberLagged)
+}
+
+func (e *SubscriberLaggedError) Unwrap() error {
+	return ErrSubscriberLagged
+}
+
+type inProcessBus struct {
+	mu          sync.Mutex
+	closed      bool
+	nextSubID   uint64
+	subscribers map[idgen.TaskID]map[uint64]*subscription
+	terminal    map[idgen.TaskID]struct{}
+}
+
+func NewBus() Bus {
+	return &inProcessBus{
+		subscribers: make(map[idgen.TaskID]map[uint64]*subscription),
+		terminal:    make(map[idgen.TaskID]struct{}),
+	}
+}
+
+func (b *inProcessBus) Publish(ctx context.Context, event Event) (int, int) {
+	if ctx.Err() != nil || event.TaskID == "" {
+		return 0, 0
+	}
+
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		return 0, 0
+	}
+	taskSubscribers := b.subscribers[event.TaskID]
+	matchedSubscribers := make([]*subscription, 0, len(taskSubscribers))
+	taskSubscribersAll := make([]*subscription, 0, len(taskSubscribers))
+	for _, sub := range taskSubscribers {
+		taskSubscribersAll = append(taskSubscribersAll, sub)
+		if sub.matches(event) {
+			matchedSubscribers = append(matchedSubscribers, sub)
+		}
+	}
+	terminal := isTerminalTaskEvent(event.Type)
+	if terminal {
+		b.terminal[event.TaskID] = struct{}{}
+		delete(b.subscribers, event.TaskID)
+	}
+	b.mu.Unlock()
+
+	delivered := 0
+	dropped := 0
+	for _, sub := range matchedSubscribers {
+		if sub.publish(event) {
+			delivered++
+		} else {
+			dropped++
+		}
+	}
+
+	if terminal {
+		for _, sub := range taskSubscribersAll {
+			sub.close()
+		}
+	}
+	return delivered, dropped
+}
+
+func (b *inProcessBus) Subscribe(ctx context.Context, options SubscribeOptions) (Subscription, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("subscribe task %q: %w", options.TaskID, err)
+	}
+	if options.TaskID == "" {
+		return nil, fmt.Errorf("subscribe task: %w", ErrSubscribeUnknownTask)
+	}
+	if options.BufferSize <= 0 {
+		options.BufferSize = 256
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed {
+		return nil, fmt.Errorf("subscribe task %q: %w", options.TaskID, ErrBusClosed)
+	}
+	if _, ended := b.terminal[options.TaskID]; ended {
+		return nil, fmt.Errorf("subscribe task %q: %w", options.TaskID, ErrSubscribeUnknownTask)
+	}
+
+	b.nextSubID++
+	sub := newSubscription(b, b.nextSubID, options)
+	if b.subscribers[options.TaskID] == nil {
+		b.subscribers[options.TaskID] = make(map[uint64]*subscription)
+	}
+	b.subscribers[options.TaskID][sub.id] = sub
+	return sub, nil
+}
+
+func (b *inProcessBus) Close(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("close event bus: %w", err)
+	}
+
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		return nil
+	}
+	b.closed = true
+	var subscribers []*subscription
+	for _, taskSubscribers := range b.subscribers {
+		for _, sub := range taskSubscribers {
+			subscribers = append(subscribers, sub)
+		}
+	}
+	b.subscribers = make(map[idgen.TaskID]map[uint64]*subscription)
+	b.mu.Unlock()
+
+	for _, sub := range subscribers {
+		sub.close()
+	}
+	return nil
+}
+
+func (b *inProcessBus) remove(sub *subscription) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	taskSubscribers := b.subscribers[sub.options.TaskID]
+	if taskSubscribers == nil {
+		return
+	}
+	delete(taskSubscribers, sub.id)
+	if len(taskSubscribers) == 0 {
+		delete(b.subscribers, sub.options.TaskID)
+	}
+}
+
+type subscription struct {
+	bus     *inProcessBus
+	id      uint64
+	options SubscribeOptions
+	events  chan Event
+	errors  chan error
+	dropped atomic.Uint64
+	mu      sync.Mutex
+	closed  bool
+	once    sync.Once
+}
+
+func newSubscription(bus *inProcessBus, id uint64, options SubscribeOptions) *subscription {
+	return &subscription{
+		bus:     bus,
+		id:      id,
+		options: options,
+		events:  make(chan Event, options.BufferSize),
+		errors:  make(chan error, 1),
+	}
+}
+
+func (s *subscription) Events() <-chan Event {
+	return s.events
+}
+
+func (s *subscription) Errors() <-chan error {
+	return s.errors
+}
+
+func (s *subscription) Dropped() uint64 {
+	return s.dropped.Load()
+}
+
+func (s *subscription) Close() error {
+	s.bus.remove(s)
+	s.close()
+	return nil
+}
+
+func (s *subscription) close() {
+	s.once.Do(func() {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		s.closed = true
+		close(s.events)
+		close(s.errors)
+	})
+}
+
+func (s *subscription) matches(event Event) bool {
+	if event.TaskID != s.options.TaskID {
+		return false
+	}
+	if s.options.SessionID != "" && event.SessionID != s.options.SessionID {
+		return false
+	}
+	if s.options.RequestID != "" && event.RequestID != s.options.RequestID {
+		return false
+	}
+	if !s.options.IncludeChunks && event.Type == EventTypeRequestTextChunk {
+		return false
+	}
+	return true
+}
+
+func (s *subscription) publish(event Event) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return false
+	}
+	select {
+	case s.events <- event:
+		return true
+	default:
+		dropped := s.dropped.Add(1)
+		err := &SubscriberLaggedError{
+			TaskID:     event.TaskID,
+			SessionID:  event.SessionID,
+			RequestID:  event.RequestID,
+			EventType:  event.Type,
+			EventSeq:   event.Seq,
+			Dropped:    dropped,
+			Subscriber: fmt.Sprintf("%d", s.id),
+		}
+		select {
+		case s.errors <- err:
+		default:
+			select {
+			case <-s.errors:
+			default:
+			}
+			select {
+			case s.errors <- err:
+			default:
+			}
+		}
+		return false
+	}
+}
+
+func isTerminalTaskEvent(typ EventType) bool {
+	switch typ {
+	case EventTypeTaskCompleted, EventTypeTaskFailed, EventTypeTaskCancelled:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/orchestrator/events/events_test.go
+++ b/pkg/orchestrator/events/events_test.go
@@ -3,6 +3,7 @@ package events
 import (
 	"context"
 	"errors"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -141,6 +142,78 @@ func TestBus_SubscribeSuppressesChunksByDefault(t *testing.T) {
 	assertNoEvent(t, sub.Events())
 }
 
+func TestBus_SubscribeIncludesChunksWhenRequested(t *testing.T) {
+	ctx := context.Background()
+	bus := NewBus()
+	sub, err := bus.Subscribe(ctx, SubscribeOptions{TaskID: "task-1", BufferSize: 1, IncludeChunks: true})
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+	defer sub.Close()
+
+	delivered, dropped := bus.Publish(ctx, testBusEvent("task-1", "session-1", "request-1", EventTypeRequestTextChunk, 1))
+	if delivered != 1 || dropped != 0 {
+		t.Fatalf("chunk Publish() delivered/dropped = %d/%d, want 1/0", delivered, dropped)
+	}
+	if got := receiveEvent(t, sub.Events()); got.Type != EventTypeRequestTextChunk {
+		t.Fatalf("event type = %q, want %q", got.Type, EventTypeRequestTextChunk)
+	}
+}
+
+func TestBus_DefaultBufferSizeAllowsMultipleEvents(t *testing.T) {
+	ctx := context.Background()
+	bus := NewBus()
+	sub, err := bus.Subscribe(ctx, SubscribeOptions{TaskID: "task-1"})
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+	defer sub.Close()
+
+	for seq := uint64(1); seq <= 2; seq++ {
+		delivered, dropped := bus.Publish(ctx, testBusEvent("task-1", "", "", EventTypeTaskRunning, seq))
+		if delivered != 1 || dropped != 0 {
+			t.Fatalf("Publish(seq=%d) delivered/dropped = %d/%d, want 1/0", seq, delivered, dropped)
+		}
+	}
+	if got := receiveEvent(t, sub.Events()); got.Seq != 1 {
+		t.Fatalf("first seq = %d, want 1", got.Seq)
+	}
+	if got := receiveEvent(t, sub.Events()); got.Seq != 2 {
+		t.Fatalf("second seq = %d, want 2", got.Seq)
+	}
+}
+
+func TestBus_SubscribeEmptyTaskIDReturnsUnknownTask(t *testing.T) {
+	ctx := context.Background()
+	bus := NewBus()
+
+	_, err := bus.Subscribe(ctx, SubscribeOptions{TaskID: ""})
+	if !errors.Is(err, ErrSubscribeUnknownTask) {
+		t.Fatalf("Subscribe() error = %v, want ErrSubscribeUnknownTask", err)
+	}
+}
+
+func TestBus_SubscribeEmptyTaskIDWithCanceledContextReturnsUnknownTask(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	bus := NewBus()
+
+	_, err := bus.Subscribe(ctx, SubscribeOptions{TaskID: ""})
+	if !errors.Is(err, ErrSubscribeUnknownTask) {
+		t.Fatalf("Subscribe() error = %v, want ErrSubscribeUnknownTask", err)
+	}
+}
+
+func TestBus_PublishEmptyTaskIDReturnsZeroCounts(t *testing.T) {
+	ctx := context.Background()
+	bus := NewBus()
+
+	delivered, dropped := bus.Publish(ctx, testBusEvent("", "", "", EventTypeTaskRunning, 1))
+	if delivered != 0 || dropped != 0 {
+		t.Fatalf("Publish() delivered/dropped = %d/%d, want 0/0", delivered, dropped)
+	}
+}
+
 func TestBus_SlowSubscriberDropsWithoutBlockingFastSubscriber(t *testing.T) {
 	ctx := context.Background()
 	bus := NewBus()
@@ -229,6 +302,31 @@ func TestBus_TerminalTaskEventClosesSubscription(t *testing.T) {
 	}
 }
 
+func TestBus_TerminalTaskEventWithCanceledContextStillClosesSubscription(t *testing.T) {
+	ctx := context.Background()
+	bus := NewBus()
+	sub, err := bus.Subscribe(ctx, SubscribeOptions{TaskID: "task-1", BufferSize: 2})
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+	canceledCtx, cancel := context.WithCancel(ctx)
+	cancel()
+
+	delivered, dropped := bus.Publish(canceledCtx, testBusEvent("task-1", "", "", EventTypeTaskCompleted, 1))
+	if delivered != 1 || dropped != 0 {
+		t.Fatalf("Publish() delivered/dropped = %d/%d, want 1/0", delivered, dropped)
+	}
+	if got := receiveEvent(t, sub.Events()); got.Type != EventTypeTaskCompleted {
+		t.Fatalf("event type = %q, want %q", got.Type, EventTypeTaskCompleted)
+	}
+	assertChannelClosed(t, sub.Events())
+
+	_, err = bus.Subscribe(ctx, SubscribeOptions{TaskID: "task-1", BufferSize: 1})
+	if !errors.Is(err, ErrSubscribeUnknownTask) {
+		t.Fatalf("Subscribe() after terminal error = %v, want ErrSubscribeUnknownTask", err)
+	}
+}
+
 func TestBus_TerminalTaskEventClosesScopedSubscription(t *testing.T) {
 	ctx := context.Background()
 	bus := NewBus()
@@ -265,6 +363,98 @@ func TestSubscription_CloseIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestBus_CloseClosesExistingSubscriber(t *testing.T) {
+	ctx := context.Background()
+	bus := NewBus()
+	sub, err := bus.Subscribe(ctx, SubscribeOptions{TaskID: "task-1", BufferSize: 1})
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+
+	if err := bus.Close(ctx); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	assertChannelClosed(t, sub.Events())
+}
+
+func TestBus_CloseWithCanceledContextStillClosesSubscribersAndRejectsFutureUse(t *testing.T) {
+	ctx := context.Background()
+	bus := NewBus()
+	sub, err := bus.Subscribe(ctx, SubscribeOptions{TaskID: "task-1", BufferSize: 1})
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+	canceledCtx, cancel := context.WithCancel(ctx)
+	cancel()
+
+	err = bus.Close(canceledCtx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Close() error = %v, want context.Canceled", err)
+	}
+	assertChannelClosed(t, sub.Events())
+
+	delivered, dropped := bus.Publish(ctx, testBusEvent("task-1", "", "", EventTypeTaskRunning, 1))
+	if delivered != 0 || dropped != 0 {
+		t.Fatalf("Publish() after canceled close delivered/dropped = %d/%d, want 0/0", delivered, dropped)
+	}
+	_, err = bus.Subscribe(ctx, SubscribeOptions{TaskID: "task-1", BufferSize: 1})
+	if !errors.Is(err, ErrBusClosed) {
+		t.Fatalf("Subscribe() after canceled close error = %v, want ErrBusClosed", err)
+	}
+}
+
+func TestBus_ConcurrentCloseWaitsForSubscriberChannelsToClose(t *testing.T) {
+	ctx := context.Background()
+	bus := NewBus()
+	concreteBus := bus.(*inProcessBus)
+	sub, err := bus.Subscribe(ctx, SubscribeOptions{TaskID: "task-1", BufferSize: 1})
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+
+	concreteBus.activePublishes.Add(1)
+	var releaseActivePublish sync.Once
+	t.Cleanup(func() {
+		releaseActivePublish.Do(concreteBus.activePublishes.Done)
+	})
+	firstCloseDone := make(chan error, 1)
+	go func() {
+		firstCloseDone <- bus.Close(ctx)
+	}()
+	waitForBusClosed(t, concreteBus)
+
+	secondCloseDone := make(chan error, 1)
+	go func() {
+		err := bus.Close(ctx)
+		select {
+		case _, ok := <-sub.Events():
+			if ok {
+				t.Error("second Close returned before subscriber channel closed")
+			}
+		default:
+			t.Error("second Close returned before subscriber channel closed")
+		}
+		secondCloseDone <- err
+	}()
+
+	for range 1000 {
+		select {
+		case err := <-secondCloseDone:
+			t.Fatalf("second Close returned before in-flight publish completed: %v", err)
+		default:
+			runtime.Gosched()
+		}
+	}
+
+	releaseActivePublish.Do(concreteBus.activePublishes.Done)
+	if err := receiveCloseResult(t, firstCloseDone); err != nil {
+		t.Fatalf("first Close() error = %v", err)
+	}
+	if err := receiveCloseResult(t, secondCloseDone); err != nil {
+		t.Fatalf("second Close() error = %v", err)
+	}
+}
+
 func TestBus_PublishAfterCloseIsDeterministic(t *testing.T) {
 	ctx := context.Background()
 	bus := NewBus()
@@ -280,6 +470,93 @@ func TestBus_PublishAfterCloseIsDeterministic(t *testing.T) {
 	if !errors.Is(err, ErrBusClosed) {
 		t.Fatalf("Subscribe() after close error = %v, want ErrBusClosed", err)
 	}
+}
+
+func TestBus_SubscribeAfterCloseWithCanceledContextReturnsBusClosed(t *testing.T) {
+	ctx := context.Background()
+	bus := NewBus()
+	if err := bus.Close(ctx); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	canceledCtx, cancel := context.WithCancel(ctx)
+	cancel()
+
+	_, err := bus.Subscribe(canceledCtx, SubscribeOptions{TaskID: "task-1"})
+	if !errors.Is(err, ErrBusClosed) {
+		t.Fatalf("Subscribe() after close error = %v, want ErrBusClosed", err)
+	}
+}
+
+func TestBus_PublishIgnoresInactiveSubscriber(t *testing.T) {
+	ctx := context.Background()
+	bus := NewBus()
+	sub, err := bus.Subscribe(ctx, SubscribeOptions{TaskID: "task-1", BufferSize: 1})
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+	concrete := sub.(*subscription)
+	concrete.close()
+
+	delivered, dropped := bus.Publish(ctx, testBusEvent("task-1", "", "", EventTypeTaskRunning, 1))
+	if delivered != 0 || dropped != 0 {
+		t.Fatalf("Publish() delivered/dropped = %d/%d, want 0/0 for inactive subscriber", delivered, dropped)
+	}
+	if got := sub.Dropped(); got != 0 {
+		t.Fatalf("Dropped() = %d, want 0", got)
+	}
+}
+
+func TestBus_PublishRacesWithSubscriptionAndBusClose(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("subscription close", func(t *testing.T) {
+		for i := 0; i < 100; i++ {
+			bus := NewBus()
+			sub, err := bus.Subscribe(ctx, SubscribeOptions{TaskID: "task-1", BufferSize: 1, IncludeChunks: true})
+			if err != nil {
+				t.Fatalf("Subscribe() error = %v", err)
+			}
+			var wg sync.WaitGroup
+			wg.Add(2)
+			go func() {
+				defer wg.Done()
+				for seq := uint64(1); seq <= 10; seq++ {
+					bus.Publish(ctx, testBusEvent("task-1", "", "", EventTypeRequestTextChunk, seq))
+				}
+			}()
+			go func() {
+				defer wg.Done()
+				if err := sub.Close(); err != nil {
+					t.Errorf("Close() error = %v", err)
+				}
+			}()
+			wg.Wait()
+		}
+	})
+
+	t.Run("bus close", func(t *testing.T) {
+		for i := 0; i < 100; i++ {
+			bus := NewBus()
+			if _, err := bus.Subscribe(ctx, SubscribeOptions{TaskID: "task-1", BufferSize: 1, IncludeChunks: true}); err != nil {
+				t.Fatalf("Subscribe() error = %v", err)
+			}
+			var wg sync.WaitGroup
+			wg.Add(2)
+			go func() {
+				defer wg.Done()
+				for seq := uint64(1); seq <= 10; seq++ {
+					bus.Publish(ctx, testBusEvent("task-1", "", "", EventTypeRequestTextChunk, seq))
+				}
+			}()
+			go func() {
+				defer wg.Done()
+				if err := bus.Close(ctx); err != nil {
+					t.Errorf("Close() error = %v", err)
+				}
+			}()
+			wg.Wait()
+		}
+	})
 }
 
 func TestBus_ConcurrentPublishSubscribe(t *testing.T) {
@@ -415,5 +692,35 @@ func assertChannelClosed(t *testing.T, ch <-chan Event) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for event channel to close")
+	}
+}
+
+func waitForBusClosed(t *testing.T, bus *inProcessBus) {
+	t.Helper()
+	deadline := time.After(time.Second)
+	for {
+		bus.mu.Lock()
+		closed := bus.closed
+		bus.mu.Unlock()
+		if closed {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for bus to enter closing state")
+		default:
+			runtime.Gosched()
+		}
+	}
+}
+
+func receiveCloseResult(t *testing.T, ch <-chan error) error {
+	t.Helper()
+	select {
+	case err := <-ch:
+		return err
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for Close result")
+		return nil
 	}
 }

--- a/pkg/orchestrator/events/events_test.go
+++ b/pkg/orchestrator/events/events_test.go
@@ -1,0 +1,419 @@
+package events
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/AiRanthem/ANA/pkg/orchestrator/idgen"
+)
+
+func TestBus_SubscriberReceivesPublishedEvent(t *testing.T) {
+	ctx := context.Background()
+	bus := NewBus()
+	sub, err := bus.Subscribe(ctx, SubscribeOptions{TaskID: "task-1", BufferSize: 1})
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+	defer sub.Close()
+
+	delivered, dropped := bus.Publish(ctx, testBusEvent("task-1", "", "", EventTypeTaskCreated, 1))
+	if delivered != 1 || dropped != 0 {
+		t.Fatalf("Publish() delivered/dropped = %d/%d, want 1/0", delivered, dropped)
+	}
+
+	got := receiveEvent(t, sub.Events())
+	if got.Type != EventTypeTaskCreated || got.TaskID != "task-1" || got.Seq != 1 {
+		t.Fatalf("event = %#v, want task.created for task-1 seq 1", got)
+	}
+}
+
+func TestBus_DeliversEventsInPublishOrder(t *testing.T) {
+	ctx := context.Background()
+	bus := NewBus()
+	sub, err := bus.Subscribe(ctx, SubscribeOptions{TaskID: "task-1", BufferSize: 8, IncludeChunks: true})
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+	defer sub.Close()
+
+	sequence := []EventType{
+		EventTypeTaskCreated,
+		EventTypeTaskRunning,
+		EventTypeSessionOpened,
+		EventTypeRequestCreated,
+		EventTypeRequestRunning,
+		EventTypeRequestTextChunk,
+		EventTypeRequestCompleted,
+		EventTypeSessionClosed,
+	}
+	for i, typ := range sequence {
+		delivered, dropped := bus.Publish(ctx, testBusEvent("task-1", "session-1", "request-1", typ, uint64(i+1)))
+		if delivered != 1 || dropped != 0 {
+			t.Fatalf("Publish(%q) delivered/dropped = %d/%d, want 1/0", typ, delivered, dropped)
+		}
+	}
+
+	for i, want := range sequence {
+		got := receiveEvent(t, sub.Events())
+		if got.Type != want {
+			t.Fatalf("event[%d].Type = %q, want %q", i, got.Type, want)
+		}
+		if got.Seq != uint64(i+1) {
+			t.Fatalf("event[%d].Seq = %d, want %d", i, got.Seq, i+1)
+		}
+	}
+}
+
+func TestBus_MultipleSubscribersReceiveSameEvent(t *testing.T) {
+	ctx := context.Background()
+	bus := NewBus()
+	first, err := bus.Subscribe(ctx, SubscribeOptions{TaskID: "task-1", BufferSize: 1})
+	if err != nil {
+		t.Fatalf("first Subscribe() error = %v", err)
+	}
+	defer first.Close()
+	second, err := bus.Subscribe(ctx, SubscribeOptions{TaskID: "task-1", BufferSize: 1})
+	if err != nil {
+		t.Fatalf("second Subscribe() error = %v", err)
+	}
+	defer second.Close()
+
+	delivered, dropped := bus.Publish(ctx, testBusEvent("task-1", "", "", EventTypeTaskRunning, 2))
+	if delivered != 2 || dropped != 0 {
+		t.Fatalf("Publish() delivered/dropped = %d/%d, want 2/0", delivered, dropped)
+	}
+
+	if got := receiveEvent(t, first.Events()); got.Type != EventTypeTaskRunning {
+		t.Fatalf("first event type = %q, want %q", got.Type, EventTypeTaskRunning)
+	}
+	if got := receiveEvent(t, second.Events()); got.Type != EventTypeTaskRunning {
+		t.Fatalf("second event type = %q, want %q", got.Type, EventTypeTaskRunning)
+	}
+}
+
+func TestBus_SubscribeFiltersBySessionAndRequest(t *testing.T) {
+	ctx := context.Background()
+	bus := NewBus()
+	sub, err := bus.Subscribe(ctx, SubscribeOptions{
+		TaskID:     "task-1",
+		SessionID:  "session-1",
+		RequestID:  "request-1",
+		BufferSize: 2,
+	})
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+	defer sub.Close()
+
+	if delivered, dropped := bus.Publish(ctx, testBusEvent("task-1", "session-2", "request-1", EventTypeRequestCreated, 1)); delivered != 0 || dropped != 0 {
+		t.Fatalf("session mismatch delivered/dropped = %d/%d, want 0/0", delivered, dropped)
+	}
+	if delivered, dropped := bus.Publish(ctx, testBusEvent("task-1", "session-1", "request-2", EventTypeRequestCreated, 2)); delivered != 0 || dropped != 0 {
+		t.Fatalf("request mismatch delivered/dropped = %d/%d, want 0/0", delivered, dropped)
+	}
+	if delivered, dropped := bus.Publish(ctx, testBusEvent("task-1", "session-1", "request-1", EventTypeRequestCreated, 3)); delivered != 1 || dropped != 0 {
+		t.Fatalf("matching event delivered/dropped = %d/%d, want 1/0", delivered, dropped)
+	}
+
+	got := receiveEvent(t, sub.Events())
+	if got.SessionID != "session-1" || got.RequestID != "request-1" || got.Seq != 3 {
+		t.Fatalf("event = %#v, want matching session/request seq 3", got)
+	}
+	assertNoEvent(t, sub.Events())
+}
+
+func TestBus_SubscribeSuppressesChunksByDefault(t *testing.T) {
+	ctx := context.Background()
+	bus := NewBus()
+	sub, err := bus.Subscribe(ctx, SubscribeOptions{TaskID: "task-1", BufferSize: 1})
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+	defer sub.Close()
+
+	delivered, dropped := bus.Publish(ctx, testBusEvent("task-1", "session-1", "request-1", EventTypeRequestTextChunk, 1))
+	if delivered != 0 || dropped != 0 {
+		t.Fatalf("chunk Publish() delivered/dropped = %d/%d, want 0/0", delivered, dropped)
+	}
+	assertNoEvent(t, sub.Events())
+}
+
+func TestBus_SlowSubscriberDropsWithoutBlockingFastSubscriber(t *testing.T) {
+	ctx := context.Background()
+	bus := NewBus()
+	slow, err := bus.Subscribe(ctx, SubscribeOptions{TaskID: "task-1", BufferSize: 1})
+	if err != nil {
+		t.Fatalf("slow Subscribe() error = %v", err)
+	}
+	defer slow.Close()
+	fast, err := bus.Subscribe(ctx, SubscribeOptions{TaskID: "task-1", BufferSize: 10})
+	if err != nil {
+		t.Fatalf("fast Subscribe() error = %v", err)
+	}
+	defer fast.Close()
+
+	delivered, dropped := bus.Publish(ctx, testBusEvent("task-1", "", "", EventTypeTaskRunning, 1))
+	if delivered != 2 || dropped != 0 {
+		t.Fatalf("first Publish() delivered/dropped = %d/%d, want 2/0", delivered, dropped)
+	}
+	delivered, dropped = bus.Publish(ctx, testBusEvent("task-1", "", "", EventTypeRouteDirective, 2))
+	if delivered != 1 || dropped != 1 {
+		t.Fatalf("second Publish() delivered/dropped = %d/%d, want 1/1", delivered, dropped)
+	}
+
+	if got := receiveEvent(t, fast.Events()); got.Seq != 1 {
+		t.Fatalf("fast first seq = %d, want 1", got.Seq)
+	}
+	if got := receiveEvent(t, fast.Events()); got.Seq != 2 {
+		t.Fatalf("fast second seq = %d, want 2", got.Seq)
+	}
+	dropErr := receiveError(t, slow.Errors())
+	var lagged *SubscriberLaggedError
+	if !errors.As(dropErr, &lagged) {
+		t.Fatalf("drop error = %v, want SubscriberLaggedError", dropErr)
+	}
+	if lagged.Dropped != 1 {
+		t.Fatalf("lagged dropped = %d, want 1", lagged.Dropped)
+	}
+}
+
+func TestBus_SlowSubscriberErrorsSurfaceLatestDropCount(t *testing.T) {
+	ctx := context.Background()
+	bus := NewBus()
+	sub, err := bus.Subscribe(ctx, SubscribeOptions{TaskID: "task-1", BufferSize: 2})
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+	defer sub.Close()
+
+	bus.Publish(ctx, testBusEvent("task-1", "", "", EventTypeTaskRunning, 1))
+	bus.Publish(ctx, testBusEvent("task-1", "", "", EventTypeTaskRunning, 2))
+	for seq := uint64(3); seq <= 6; seq++ {
+		bus.Publish(ctx, testBusEvent("task-1", "", "", EventTypeRouteDirective, seq))
+	}
+
+	dropErr := receiveError(t, sub.Errors())
+	var lagged *SubscriberLaggedError
+	if !errors.As(dropErr, &lagged) {
+		t.Fatalf("drop error = %v, want SubscriberLaggedError", dropErr)
+	}
+	if lagged.Dropped != 4 || sub.Dropped() != 4 {
+		t.Fatalf("drop counts error/sub = %d/%d, want 4/4", lagged.Dropped, sub.Dropped())
+	}
+	assertNoError(t, sub.Errors())
+}
+
+func TestBus_TerminalTaskEventClosesSubscription(t *testing.T) {
+	ctx := context.Background()
+	bus := NewBus()
+	sub, err := bus.Subscribe(ctx, SubscribeOptions{TaskID: "task-1", BufferSize: 2})
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+
+	delivered, dropped := bus.Publish(ctx, testBusEvent("task-1", "", "", EventTypeTaskCompleted, 1))
+	if delivered != 1 || dropped != 0 {
+		t.Fatalf("Publish() delivered/dropped = %d/%d, want 1/0", delivered, dropped)
+	}
+	if got := receiveEvent(t, sub.Events()); got.Type != EventTypeTaskCompleted {
+		t.Fatalf("event type = %q, want %q", got.Type, EventTypeTaskCompleted)
+	}
+	assertChannelClosed(t, sub.Events())
+
+	_, err = bus.Subscribe(ctx, SubscribeOptions{TaskID: "task-1", BufferSize: 1})
+	if !errors.Is(err, ErrSubscribeUnknownTask) {
+		t.Fatalf("Subscribe() after terminal error = %v, want ErrSubscribeUnknownTask", err)
+	}
+}
+
+func TestBus_TerminalTaskEventClosesScopedSubscription(t *testing.T) {
+	ctx := context.Background()
+	bus := NewBus()
+	sub, err := bus.Subscribe(ctx, SubscribeOptions{
+		TaskID:     "task-1",
+		SessionID:  "session-1",
+		RequestID:  "request-1",
+		BufferSize: 1,
+	})
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+
+	delivered, dropped := bus.Publish(ctx, testBusEvent("task-1", "", "", EventTypeTaskFailed, 1))
+	if delivered != 0 || dropped != 0 {
+		t.Fatalf("Publish() delivered/dropped = %d/%d, want 0/0 for scoped terminal close", delivered, dropped)
+	}
+	assertChannelClosed(t, sub.Events())
+}
+
+func TestSubscription_CloseIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	bus := NewBus()
+	sub, err := bus.Subscribe(ctx, SubscribeOptions{TaskID: "task-1", BufferSize: 1})
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+
+	if err := sub.Close(); err != nil {
+		t.Fatalf("first Close() error = %v", err)
+	}
+	if err := sub.Close(); err != nil {
+		t.Fatalf("second Close() error = %v", err)
+	}
+}
+
+func TestBus_PublishAfterCloseIsDeterministic(t *testing.T) {
+	ctx := context.Background()
+	bus := NewBus()
+	if err := bus.Close(ctx); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	delivered, dropped := bus.Publish(ctx, testBusEvent("task-1", "", "", EventTypeTaskCreated, 1))
+	if delivered != 0 || dropped != 0 {
+		t.Fatalf("Publish() after close delivered/dropped = %d/%d, want 0/0", delivered, dropped)
+	}
+	_, err := bus.Subscribe(ctx, SubscribeOptions{TaskID: "task-1"})
+	if !errors.Is(err, ErrBusClosed) {
+		t.Fatalf("Subscribe() after close error = %v, want ErrBusClosed", err)
+	}
+}
+
+func TestBus_ConcurrentPublishSubscribe(t *testing.T) {
+	ctx := context.Background()
+	bus := NewBus()
+	const subscribers = 8
+	const publishers = 8
+	const perPublisher = 25
+	const totalEvents = publishers * perPublisher
+
+	subs := make([]Subscription, 0, subscribers)
+	for range subscribers {
+		sub, err := bus.Subscribe(ctx, SubscribeOptions{
+			TaskID:        "task-1",
+			BufferSize:    totalEvents * 2, // headroom so a transient stall cannot cause drops
+			IncludeChunks: true,
+		})
+		if err != nil {
+			t.Fatalf("Subscribe() error = %v", err)
+		}
+		subs = append(subs, sub)
+	}
+	defer func() {
+		for _, sub := range subs {
+			if err := sub.Close(); err != nil {
+				t.Errorf("Close() error = %v", err)
+			}
+		}
+	}()
+
+	var wg sync.WaitGroup
+	for publisher := range publishers {
+		wg.Add(1)
+		go func(publisher int) {
+			defer wg.Done()
+			for seq := range perPublisher {
+				event := testBusEvent("task-1", "session-1", "request-1", EventTypeRequestTextChunk, uint64(publisher*perPublisher+seq))
+				bus.Publish(ctx, event)
+			}
+		}(publisher)
+	}
+	wg.Wait()
+
+	// Check drop counters BEFORE draining, so an unexpected drop is reported
+	// as a clean assertion failure instead of hanging on the drain loop.
+	for i, sub := range subs {
+		if dropped := sub.Dropped(); dropped != 0 {
+			t.Fatalf("sub %d Dropped() = %d before drain, want 0", i, dropped)
+		}
+	}
+
+	for i, sub := range subs {
+		for range totalEvents {
+			receiveEvent(t, sub.Events())
+		}
+		if dropped := sub.Dropped(); dropped != 0 {
+			t.Fatalf("sub %d Dropped() = %d after drain, want 0", i, dropped)
+		}
+	}
+}
+
+func testBusEvent(taskID idgen.TaskID, sessionID idgen.SessionID, requestID idgen.RequestID, typ EventType, seq uint64) Event {
+	return Event{
+		EventID:    "event",
+		TaskID:     taskID,
+		SessionID:  sessionID,
+		RequestID:  requestID,
+		Type:       typ,
+		Seq:        seq,
+		OccurredAt: time.Unix(0, int64(seq)),
+		Payload:    map[string]any{"ok": true},
+	}
+}
+
+func receiveEvent(t *testing.T, ch <-chan Event) Event {
+	t.Helper()
+	select {
+	case event, ok := <-ch:
+		if !ok {
+			t.Fatal("event channel closed before event")
+		}
+		return event
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for event")
+		return Event{}
+	}
+}
+
+func receiveError(t *testing.T, ch <-chan error) error {
+	t.Helper()
+	select {
+	case err, ok := <-ch:
+		if !ok {
+			t.Fatal("error channel closed before error")
+		}
+		return err
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for error")
+		return nil
+	}
+}
+
+func assertNoError(t *testing.T, ch <-chan error) {
+	t.Helper()
+	select {
+	case err, ok := <-ch:
+		if !ok {
+			t.Fatal("error channel closed unexpectedly")
+		}
+		t.Fatalf("unexpected error: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+}
+
+func assertNoEvent(t *testing.T, ch <-chan Event) {
+	t.Helper()
+	select {
+	case event, ok := <-ch:
+		if !ok {
+			t.Fatal("event channel closed unexpectedly")
+		}
+		t.Fatalf("unexpected event: %#v", event)
+	case <-time.After(20 * time.Millisecond):
+	}
+}
+
+func assertChannelClosed(t *testing.T, ch <-chan Event) {
+	t.Helper()
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Fatal("event channel still open")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for event channel to close")
+	}
+}

--- a/pkg/orchestrator/events/events_test.go
+++ b/pkg/orchestrator/events/events_test.go
@@ -95,6 +95,81 @@ func TestBus_MultipleSubscribersReceiveSameEvent(t *testing.T) {
 	}
 }
 
+func TestBus_PublishSnapshotsMutableJSONPayload(t *testing.T) {
+	ctx := context.Background()
+	bus := NewBus()
+	sub, err := bus.Subscribe(ctx, SubscribeOptions{TaskID: "task-1", BufferSize: 1})
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+	defer sub.Close()
+
+	items := []any{"original"}
+	blob := []byte("original")
+	nested := map[string]any{"name": "original"}
+	payload := map[string]any{
+		"items":  items,
+		"blob":   blob,
+		"nested": nested,
+	}
+	event := testBusEvent("task-1", "", "", EventTypeTaskRunning, 1)
+	event.Payload = payload
+
+	delivered, dropped := bus.Publish(ctx, event)
+	if delivered != 1 || dropped != 0 {
+		t.Fatalf("Publish() delivered/dropped = %d/%d, want 1/0", delivered, dropped)
+	}
+	items[0] = "changed"
+	blob[0] = 'X'
+	nested["name"] = "changed"
+	payload["new"] = "changed"
+
+	got := receiveEvent(t, sub.Events())
+	gotPayload := got.Payload.(map[string]any)
+	if gotPayload["items"].([]any)[0] != "original" {
+		t.Fatalf("items payload = %#v, want original snapshot", gotPayload["items"])
+	}
+	if string(gotPayload["blob"].([]byte)) != "original" {
+		t.Fatalf("blob payload = %q, want original snapshot", gotPayload["blob"])
+	}
+	if gotPayload["nested"].(map[string]any)["name"] != "original" {
+		t.Fatalf("nested payload = %#v, want original snapshot", gotPayload["nested"])
+	}
+	if _, ok := gotPayload["new"]; ok {
+		t.Fatalf("payload contains post-publish key: %#v", gotPayload)
+	}
+}
+
+func TestBus_PublishIsolatesPayloadsBetweenSubscribers(t *testing.T) {
+	ctx := context.Background()
+	bus := NewBus()
+	first, err := bus.Subscribe(ctx, SubscribeOptions{TaskID: "task-1", BufferSize: 1})
+	if err != nil {
+		t.Fatalf("first Subscribe() error = %v", err)
+	}
+	defer first.Close()
+	second, err := bus.Subscribe(ctx, SubscribeOptions{TaskID: "task-1", BufferSize: 1})
+	if err != nil {
+		t.Fatalf("second Subscribe() error = %v", err)
+	}
+	defer second.Close()
+
+	event := testBusEvent("task-1", "", "", EventTypeTaskRunning, 1)
+	event.Payload = map[string]any{"items": []any{"original"}}
+
+	delivered, dropped := bus.Publish(ctx, event)
+	if delivered != 2 || dropped != 0 {
+		t.Fatalf("Publish() delivered/dropped = %d/%d, want 2/0", delivered, dropped)
+	}
+
+	firstPayload := receiveEvent(t, first.Events()).Payload.(map[string]any)
+	secondPayload := receiveEvent(t, second.Events()).Payload.(map[string]any)
+	firstPayload["items"].([]any)[0] = "mutated"
+	if secondPayload["items"].([]any)[0] != "original" {
+		t.Fatalf("second payload = %#v, want isolated original snapshot", secondPayload)
+	}
+}
+
 func TestBus_SubscribeFiltersBySessionAndRequest(t *testing.T) {
 	ctx := context.Background()
 	bus := NewBus()


### PR DESCRIPTION
## Summary

- Introduce **`pkg/orchestrator/audit`** — synchronous, fail-fast audit sink. Defines the `Sink` interface, `EventRecord` / `TranscriptRecord` shapes, the `EventType` taxonomy, an in-memory reference sink, a fail-fast `Multi()` fan-out, transcript constructors for the fully-rendered `InvokeRequest` shape required by `DESIGN.md §9`, and a redaction round-trip that preserves replay-critical structural metadata even when policies mutate input maps/slices in place.
- Introduce **`pkg/orchestrator/events`** — best-effort runtime event bus. Task-scoped subscriptions with optional `SessionID` / `RequestID` filters, per-subscriber bounded channels with non-blocking `Publish`, drop accounting via inline `SubscriberLaggedError`, and terminal-event-driven subscription close. The `EventType` taxonomy is kept in lockstep with `audit.EventType` (the AGENTS.md no-cross-import rule forbids sharing it through a common package).
- **Align `DESIGN.md` and per-package `PLAN.md` with the shipped code.** Adds the `Seq` field (`uint64`) to the §8.2 Event schema and the §9 transcript table; declares the previously-leaked sentinels (`ErrNoSink`, `ErrRedactionStructure`) and methods (`Subscription.Dropped()`); rewrites the events Subscriber-concurrency / Drop-policy / empty-TaskID sections to match the channel-plus-mutex implementation; archives the implementation plan under `docs/superpowers/plans/` following repo convention.

## Notes for reviewers

- Two leaf packages, no orchestrator engine wiring yet. Both only depend on `pkg/orchestrator/idgen` per the dependency graph in `DESIGN.md §13.1`.
- `audit` is the synchronous fail-fast surface; `events` is the non-blocking best-effort surface. They share the `EventType` constants by duplication — both blocks carry a sync comment.
- `audit.ApplyRedaction` defensively clones nested `map[string]any` via reflection to prevent policies from corrupting structural metadata. `TestRedactionPolicy_InPlaceMutationCannotCorruptStructuralMetadata` exercises nested map / slice / typed-map paths.

## Test plan

- [ ] CI: `gofmt -s -l` clean, `go vet ./...` clean
- [ ] `go test ./pkg/orchestrator/audit/... ./pkg/orchestrator/events/... -race -count=1` passes
- [ ] `go build ./...` clean
- [ ] Manual: verify `TestMemorySink_ConcurrentWritesAreSafe` and `TestBus_ConcurrentPublishSubscribe` pass under `-race`
- [ ] Manual: confirm `DESIGN.md §8.2` and both `PLAN.md` files describe the same Event/Subscription surface as the code